### PR TITLE
Wrappers for OCTToxAV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 script:
     - pod install
     - xctool -workspace objcTox.xcworkspace -scheme objcToxDemo -sdk iphonesimulator build
-    - xctool -workspace objcTox.xcworkspace -scheme objcToxDemo -sdk iphonesimulator GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean test
+    - xctool -workspace objcTox.xcworkspace -scheme objcToxDemo -destination 'platform=iOS Simulator,name=iPhone 6' -sdk iphonesimulator GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean test
     - ./run-uncrustify.sh --check
 #   - pod lib lint --quick
 #

--- a/Classes/Private/Wrapper/OCTTox+Private.h
+++ b/Classes/Private/Wrapper/OCTTox+Private.h
@@ -1,0 +1,16 @@
+//
+//  OCTTox+Private.h
+//  objcTox
+//
+//  Created by Chuong Vu on 6/2/15.
+//  Copyright (c) 2015 dvor. All rights reserved.
+//
+
+#import "OCTTox.h"
+#import "tox.h"
+
+@interface OCTTox (Private)
+
+@property (assign, nonatomic) Tox *tox;
+
+@end

--- a/Classes/Private/Wrapper/OCTToxAV.m
+++ b/Classes/Private/Wrapper/OCTToxAV.m
@@ -144,8 +144,6 @@ toxav_video_receive_frame_cb receiveVideoFrameCallback;
 
 - (BOOL)callFriendNumber:(OCTToxFriendNumber)friendNumber audioBitRate:(OCTToxAVAudioBitRate)audioBitRate videoBitRate:(OCTToxAVVideoBitRate)videoBitRate error:(NSError **)error
 {
-    NSParameterAssert(friendNumber);
-
     TOXAV_ERR_CALL cError;
     BOOL status = toxav_call(self.toxAV, friendNumber, audioBitRate, videoBitRate, &cError);
 

--- a/Classes/Private/Wrapper/OCTToxAV.m
+++ b/Classes/Private/Wrapper/OCTToxAV.m
@@ -7,7 +7,213 @@
 //
 
 #import "OCTToxAV.h"
+#import "OCTTox+Private.h"
+#import "toxav.h"
+#import "DDLog.h"
+
+#undef LOG_LEVEL_DEF
+#define LOG_LEVEL_DEF LOG_LEVEL_VERBOSE
+
+@interface OCTToxAV ()
+
+@property (assign, nonatomic) ToxAV *toxAV;
+
+@property (strong, nonatomic) dispatch_source_t timer;
+
+@end
 
 @implementation OCTToxAV
 
+#pragma mark - Class Methods
+
++ (NSString *)version
+{
+    return [NSString stringWithFormat:@"%lu.%lu.%lu",
+            (unsigned long)[self versionMajor], (unsigned long)[self versionMinor], (unsigned long)[self versionPatch]];
+}
+
++ (NSUInteger)versionMajor
+{
+    return toxav_version_major();
+}
+
++ (NSUInteger)versionMinor
+{
+    return toxav_version_minor();
+}
+
++ (NSUInteger)versionPatch
+{
+    return toxav_version_patch();
+}
+
++ (BOOL)versionIsCompatibleWith:(NSUInteger)major minor:(NSUInteger)minor patch:(NSUInteger)patch
+{
+    return toxav_version_is_compatible((uint32_t)major, (uint32_t)minor, (uint32_t)patch);
+}
+
+#pragma mark -  Lifecycle
+- (instancetype)initWithTox:(OCTTox *)tox error:(NSError **)error
+{
+    self = [super init];
+
+    if (! self) {
+        return nil;
+    }
+
+    TOXAV_ERR_NEW cError;
+    _toxAV = toxav_new(tox.tox, &cError);
+
+    [self fillError:error withCErrorInit:cError];
+    DDLogVerbose(@"%@: init called", self);
+
+    return self;
+}
+
+- (void)start
+{
+    DDLogVerbose(@"%@: start method called", self);
+
+    @synchronized(self) {
+        if (self.timer) {
+            DDLogWarn(@"%@: already started", self);
+            return;
+        }
+
+        dispatch_queue_t queue = dispatch_queue_create("me.dvor.objcTox.OCTToxAVQueue", NULL);
+        self.timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
+
+        uint64_t interval = toxav_iteration_interval(self.toxAV) * (NSEC_PER_SEC / 1000);
+        dispatch_source_set_timer(self.timer, dispatch_walltime(NULL, 0), interval, interval / 5);
+
+        __weak OCTToxAV *weakSelf = self;
+        dispatch_source_set_event_handler(self.timer, ^{
+            OCTToxAV *strongSelf = weakSelf;
+            if (! strongSelf) {
+                return;
+            }
+
+            toxav_iterate(strongSelf.toxAV);
+        });
+
+        dispatch_resume(self.timer);
+    }
+    DDLogInfo(@"%@: started", self);
+}
+
+- (void)stop
+{
+    DDLogVerbose(@"%@: stop method called", self);
+
+    @synchronized(self) {
+        if (! self.timer) {
+            DDLogWarn(@"%@: toxav isn't running, nothing to stop", self);
+            return;
+        }
+
+        dispatch_source_cancel(self.timer);
+        self.timer = nil;
+    }
+
+    DDLogInfo(@"%@: stopped", self);
+}
+
+- (void)dealloc
+{
+    toxav_kill(self.toxAV);
+    DDLogVerbose(@"%@: dealloc called, toxav killed", self);
+}
+
+#pragma mark - Call Methods
+
+- (BOOL)callFriendNumber:(OCTToxFriendNumber)friendNumber audioBitRate:(OCTToxAVAudioBitRate)audioBitRate videoBitRate:(OCTToxAVVideoBitRate)videoBitRate error:(NSError **)error
+{
+    TOXAV_ERR_CALL cError;
+    BOOL status = toxav_call(self.toxAV, friendNumber, audioBitRate, videoBitRate, &cError);
+
+    [self fillError:error withCErrorCall:cError];
+
+    return status;
+}
+
+#pragma mark - Private
+
+- (void)fillError:(NSError **)error withCErrorInit:(TOXAV_ERR_NEW)cError
+{
+    if (! error || (cError == TOXAV_ERR_NEW_OK)) {
+        return;
+    }
+
+    OCTToxAVErrorInitCode code = OCTToxAVErrorInitCodeUnknown;
+    NSString *description = @"Cannot initialize ToxAV";
+    NSString *failureReason = nil;
+
+    switch (cError) {
+        case TOXAV_ERR_NEW_OK:
+            NSAssert(NO, @"We shouldn't be here!");
+            break;
+            return;
+        case TOXAV_ERR_NEW_NULL:
+            code = OCTToxAVErrorInitNULL;
+            break;
+        case TOXAV_ERR_NEW_MALLOC:
+            code = OCTToxAVErrorInitCodeMemoryError;
+            break;
+        case TOXAV_ERR_NEW_MULTIPLE:
+            code = OCTToxAVErrorInitMultiple;
+            break;
+    }
+    *error = [self createErrorWithCode:code description:description failureReason:failureReason];
+}
+
+- (void)fillError:(NSError **)error withCErrorCall:(TOXAV_ERR_CALL)cError
+{
+    if (! error || (cError == TOXAV_ERR_CALL_OK)) {
+        return;
+    }
+
+    OCTToxAVErrorCall code = OCTToxAVErrorCallUnknown;
+    NSString *description = @"Could not make call";
+    NSString *failureReason = nil;
+
+    switch (cError) {
+        case TOXAV_ERR_CALL_OK:
+            NSAssert(NO, @"We shouldn't be here!");
+            break;
+        case TOXAV_ERR_CALL_MALLOC:
+            code = OCTToxAVErrorCallMalloc;
+            break;
+        case TOXAV_ERR_CALL_FRIEND_NOT_FOUND:
+            code = OCTToxAVErrorCallFriendNotFound;
+            break;
+        case TOXAV_ERR_CALL_FRIEND_NOT_CONNECTED:
+            code = OCTToxAVErrorCallFriendNotConnected;
+            break;
+        case TOXAV_ERR_CALL_FRIEND_ALREADY_IN_CALL:
+            code = OCTToxAVErrorCallAlreadyInCall;
+            break;
+        case TOXAV_ERR_CALL_INVALID_BIT_RATE:
+            code = OCTToxAVErrorCallInvalidBitRate;
+            break;
+    }
+
+    *error = [self createErrorWithCode:code description:description failureReason:failureReason];
+}
+
+- (NSError *)createErrorWithCode:(NSUInteger)code
+                     description:(NSString *)description
+                   failureReason:(NSString *)failureReason
+{
+    NSMutableDictionary *userInfo = [NSMutableDictionary new];
+
+    if (description) {
+        userInfo[NSLocalizedDescriptionKey] = description;
+    }
+
+    if (failureReason) {
+        userInfo[NSLocalizedFailureReasonErrorKey] = failureReason;
+    }
+
+    return [NSError errorWithDomain:kOCTToxAVErrorDomain code:code userInfo:userInfo];
+}
 @end

--- a/Classes/Private/Wrapper/OCTToxAV.m
+++ b/Classes/Private/Wrapper/OCTToxAV.m
@@ -14,6 +14,13 @@
 #undef LOG_LEVEL_DEF
 #define LOG_LEVEL_DEF LOG_LEVEL_VERBOSE
 
+toxav_call_cb callIncomingCallback;
+toxav_call_state_cb callstateCallback;
+toxav_audio_bit_rate_status_cb audioBitRateStatusCallback;
+toxav_video_bit_rate_status_cb videoBitRateStatusCallback;
+toxav_audio_receive_frame_cb receiveAudioFrameCallback;
+toxav_video_receive_frame_cb receiveVideoFrameCallback;
+
 @interface OCTToxAV ()
 
 @property (assign, nonatomic) ToxAV *toxAV;
@@ -61,11 +68,19 @@
         return nil;
     }
 
+    DDLogVerbose(@"%@: init called", self);
+
     TOXAV_ERR_NEW cError;
     _toxAV = toxav_new(tox.tox, &cError);
 
     [self fillError:error withCErrorInit:cError];
-    DDLogVerbose(@"%@: init called", self);
+
+    toxav_callback_call(_toxAV, callIncomingCallback, (__bridge void *)(self));
+    toxav_callback_call_state(_toxAV, callstateCallback, (__bridge void *)(self));
+    toxav_callback_audio_bit_rate_status(_toxAV, audioBitRateStatusCallback, (__bridge void *)(self));
+    toxav_callback_video_bit_rate_status(_toxAV, videoBitRateStatusCallback, (__bridge void *)(self));
+    toxav_callback_audio_receive_frame(_toxAV, receiveAudioFrameCallback, (__bridge void *)(self));
+    toxav_callback_video_receive_frame(_toxAV, receiveVideoFrameCallback, (__bridge void *)(self));
 
     return self;
 }
@@ -128,6 +143,8 @@
 
 - (BOOL)callFriendNumber:(OCTToxFriendNumber)friendNumber audioBitRate:(OCTToxAVAudioBitRate)audioBitRate videoBitRate:(OCTToxAVVideoBitRate)videoBitRate error:(NSError **)error
 {
+    NSParameterAssert(friendNumber);
+
     TOXAV_ERR_CALL cError;
     BOOL status = toxav_call(self.toxAV, friendNumber, audioBitRate, videoBitRate, &cError);
 
@@ -216,4 +233,37 @@
 
     return [NSError errorWithDomain:kOCTToxAVErrorDomain code:code userInfo:userInfo];
 }
+
 @end
+
+#pragma Callbacks
+
+void callIncomingCallback(ToxAV *cToxAV, OCTToxFriendNumber friendNumber, bool audioEnabled, bool videoEnabled, void *userData)
+{
+    //To Do..
+}
+
+void callstateCallback(ToxAV *cToxAV, OCTToxFriendNumber friendNumber, uint32_t state, void *userData)
+{
+    //To Do..
+}
+
+void audioBitRateStatusCallback(ToxAV *cToxAV, OCTToxFriendNumber friendNumber, bool stable, OCTToxAVAudioBitRate bitRate, void *userData)
+{
+    //To Do..
+}
+
+void videoBitRateStatusCallback(ToxAV *cToxAV, OCTToxFriendNumber friendNumber, bool stable, OCTToxAVVideoBitRate bitRate, void *userData)
+{
+    //To Do..
+}
+
+void receiveAudioFrameCallback(ToxAV *cToxAv, OCTToxFriendNumber friendNumber, OCTToxAVPCMData *pcm, OCTToxAVSampleCount sampleCount, OCTToxAVChannels channels, OCTToxAVSampleRate sampleRate, void *userData)
+{
+    //To Do..
+}
+
+void receiveVideoFrameCallback(ToxAV *cToxAV, OCTToxFriendNumber friendNumber, OCTToxAVVideoWidth width, OCTToxAVVideoHeight height, OCTToxAVPlaneData *yPlane, OCTToxAVPlaneData *uPlane, OCTToxAVPlaneData *vPlane, OCTToxAVPlaneData *aPlane, OCTToxAVStrideData yStride, OCTToxAVStrideData uStride, OCTToxAVStrideData vStride, OCTToxAVStrideData aStride, void *userData)
+{
+    //To Do..
+}

--- a/Classes/Private/Wrapper/OCTToxAV.m
+++ b/Classes/Private/Wrapper/OCTToxAV.m
@@ -169,7 +169,7 @@ toxav_video_receive_frame_cb receiveVideoFrameCallback;
     switch (cError) {
         case TOXAV_ERR_NEW_OK:
             NSAssert(NO, @"We shouldn't be here!");
-            return;
+            break;
         case TOXAV_ERR_NEW_NULL:
             code = OCTToxAVErrorInitNULL;
             failureReason = @"One of the arguments to the function was NULL when it was not expected.";

--- a/Classes/Private/Wrapper/OCTToxAV.m
+++ b/Classes/Private/Wrapper/OCTToxAV.m
@@ -135,6 +135,7 @@ toxav_video_receive_frame_cb receiveVideoFrameCallback;
 
 - (void)dealloc
 {
+    [self stop];
     toxav_kill(self.toxAV);
     DDLogVerbose(@"%@: dealloc called, toxav killed", self);
 }
@@ -168,16 +169,18 @@ toxav_video_receive_frame_cb receiveVideoFrameCallback;
     switch (cError) {
         case TOXAV_ERR_NEW_OK:
             NSAssert(NO, @"We shouldn't be here!");
-            break;
             return;
         case TOXAV_ERR_NEW_NULL:
             code = OCTToxAVErrorInitNULL;
+            failureReason = @"One of the arguments to the function was NULL when it was not expected.";
             break;
         case TOXAV_ERR_NEW_MALLOC:
             code = OCTToxAVErrorInitCodeMemoryError;
+            failureReason = @"Memory allocation failure while trying to allocate structures required for the A/V session.";
             break;
         case TOXAV_ERR_NEW_MULTIPLE:
             code = OCTToxAVErrorInitMultiple;
+            failureReason = @"Attempted to create a second session for the same Tox instance.";
             break;
     }
     *error = [self createErrorWithCode:code description:description failureReason:failureReason];
@@ -199,18 +202,23 @@ toxav_video_receive_frame_cb receiveVideoFrameCallback;
             break;
         case TOXAV_ERR_CALL_MALLOC:
             code = OCTToxAVErrorCallMalloc;
+            failureReason = @"A resource allocation error occured while trying to create the structures required for the call.";
             break;
         case TOXAV_ERR_CALL_FRIEND_NOT_FOUND:
             code = OCTToxAVErrorCallFriendNotFound;
+            failureReason = @"The friend number did not designate a valid friend.";
             break;
         case TOXAV_ERR_CALL_FRIEND_NOT_CONNECTED:
             code = OCTToxAVErrorCallFriendNotConnected;
+            failureReason = @"The friend was valid, but not currently connected";
             break;
         case TOXAV_ERR_CALL_FRIEND_ALREADY_IN_CALL:
             code = OCTToxAVErrorCallAlreadyInCall;
+            failureReason = @"Attempted to call a friend while already in an audio or video call with them.";
             break;
         case TOXAV_ERR_CALL_INVALID_BIT_RATE:
             code = OCTToxAVErrorCallInvalidBitRate;
+            failureReason = @"Audio or video bit rate is invalid";
             break;
     }
 
@@ -238,32 +246,59 @@ toxav_video_receive_frame_cb receiveVideoFrameCallback;
 
 #pragma Callbacks
 
-void callIncomingCallback(ToxAV *cToxAV, OCTToxFriendNumber friendNumber, bool audioEnabled, bool videoEnabled, void *userData)
+void callIncomingCallback(ToxAV *cToxAV,
+                          OCTToxFriendNumber friendNumber,
+                          bool audioEnabled,
+                          bool videoEnabled,
+                          void *userData)
 {
-    //To Do..
+    // To Do..
 }
 
-void callstateCallback(ToxAV *cToxAV, OCTToxFriendNumber friendNumber, uint32_t state, void *userData)
+void callstateCallback(ToxAV *cToxAV,
+                       OCTToxFriendNumber friendNumber,
+                       uint32_t state,
+                       void *userData)
 {
-    //To Do..
+    // To Do..
 }
 
-void audioBitRateStatusCallback(ToxAV *cToxAV, OCTToxFriendNumber friendNumber, bool stable, OCTToxAVAudioBitRate bitRate, void *userData)
+void audioBitRateStatusCallback(ToxAV *cToxAV,
+                                OCTToxFriendNumber friendNumber,
+                                bool stable,
+                                OCTToxAVAudioBitRate bitRate,
+                                void *userData)
 {
-    //To Do..
+    // To Do..
 }
 
-void videoBitRateStatusCallback(ToxAV *cToxAV, OCTToxFriendNumber friendNumber, bool stable, OCTToxAVVideoBitRate bitRate, void *userData)
+void videoBitRateStatusCallback(ToxAV *cToxAV,
+                                OCTToxFriendNumber friendNumber,
+                                bool stable,
+                                OCTToxAVVideoBitRate bitRate,
+                                void *userData)
 {
-    //To Do..
+    // To Do..
 }
 
-void receiveAudioFrameCallback(ToxAV *cToxAv, OCTToxFriendNumber friendNumber, OCTToxAVPCMData *pcm, OCTToxAVSampleCount sampleCount, OCTToxAVChannels channels, OCTToxAVSampleRate sampleRate, void *userData)
+void receiveAudioFrameCallback(ToxAV *cToxAv,
+                               OCTToxFriendNumber friendNumber,
+                               OCTToxAVPCMData *pcm,
+                               OCTToxAVSampleCount sampleCount,
+                               OCTToxAVChannels channels,
+                               OCTToxAVSampleRate sampleRate,
+                               void *userData)
 {
-    //To Do..
+    // To Do..
 }
 
-void receiveVideoFrameCallback(ToxAV *cToxAV, OCTToxFriendNumber friendNumber, OCTToxAVVideoWidth width, OCTToxAVVideoHeight height, OCTToxAVPlaneData *yPlane, OCTToxAVPlaneData *uPlane, OCTToxAVPlaneData *vPlane, OCTToxAVPlaneData *aPlane, OCTToxAVStrideData yStride, OCTToxAVStrideData uStride, OCTToxAVStrideData vStride, OCTToxAVStrideData aStride, void *userData)
+void receiveVideoFrameCallback(ToxAV *cToxAV,
+                               OCTToxFriendNumber friendNumber,
+                               OCTToxAVVideoWidth width,
+                               OCTToxAVVideoHeight height,
+                               OCTToxAVPlaneData *yPlane, OCTToxAVPlaneData *uPlane, OCTToxAVPlaneData *vPlane, OCTToxAVPlaneData *aPlane,
+                               OCTToxAVStrideData yStride, OCTToxAVStrideData uStride, OCTToxAVStrideData vStride, OCTToxAVStrideData aStride,
+                               void *userData)
 {
-    //To Do..
+    // To Do..
 }

--- a/Classes/Private/Wrapper/OCTToxAVConstants.m
+++ b/Classes/Private/Wrapper/OCTToxAVConstants.m
@@ -1,0 +1,11 @@
+//
+//  OCTToxAvConstants.m
+//  objcTox
+//
+//  Created by Chuong Vu on 6/2/15.
+//  Copyright (c) 2015 dvor. All rights reserved.
+//
+
+#import "OCTToxAVConstants.h"
+
+NSString *const kOCTToxAVErrorDomain = @"me.dvor.objcTox.ErrorDomain";

--- a/Classes/Private/Wrapper/OCTToxAVConstants.m
+++ b/Classes/Private/Wrapper/OCTToxAVConstants.m
@@ -8,4 +8,6 @@
 
 #import "OCTToxAVConstants.h"
 
+const OCTToxAVAudioBitRate kOCTToxAVAudioBitRateDisable = 0;
+const OCTToxAVVideoBitRate kOCTToxAVVideoBitRateDisable = 0;
 NSString *const kOCTToxAVErrorDomain = @"me.dvor.objcTox.ErrorDomain";

--- a/Classes/Public/Wrapper/OCTToxAV.h
+++ b/Classes/Public/Wrapper/OCTToxAV.h
@@ -18,7 +18,7 @@
 #pragma mark - Class Methods
 
 /**
- * Return toxcore version in format X.Y.Z, where
+ * Return toxav version in format X.Y.Z, where
  * X - The major version number.
  * Y - The minor version number.
  * Z - The patch or revision number.
@@ -66,8 +66,8 @@
  * if such behaviour is desired. If the client does not stop ringing, the
  * library will not stop until the friend is disconnected.
  * @param friendNumber The friend number of the friend that should be called.
- * @param audioBitRate Audio bit rate in Kb/sec. Set this to 0 to disable audio sending.
- * @param videoBitRate Video bit rate in Kb/sec. Set this to 0 to disable
+ * @param audioBitRate Audio bit rate in Kb/sec. Set this to kOCTToxAVAudioBitRateDisable to disable audio sending.
+ * @param videoBitRate Video bit rate in Kb/sec. Set this to kOCTToxAVVideoBitRateDisable to disable video sending.
  * video sending.
  */
 - (BOOL)callFriendNumber:(OCTToxFriendNumber)friendNumber audioBitRate:(OCTToxAVAudioBitRate)audioBitRate videoBitRate:(OCTToxAVVideoBitRate)videoBitRate error:(NSError **)error;

--- a/Classes/Public/Wrapper/OCTToxAV.h
+++ b/Classes/Public/Wrapper/OCTToxAV.h
@@ -8,8 +8,68 @@
 
 #import <Foundation/Foundation.h>
 
+#import "OCTToxAVConstants.h"
+#import "OCTToxConstants.h"
+
+@class OCTTox;
+
 @interface OCTToxAV : NSObject
 
+#pragma mark - Class Methods
 
+/**
+ * Return toxcore version in format X.Y.Z, where
+ * X - The major version number.
+ * Y - The minor version number.
+ * Z - The patch or revision number.
+ */
++ (NSString *)version;
+
+/**
+ * The major version number of toxav. Can be used to display the
+ * ToxAV library version or to check whether the client is compatible with the
+ * dynamically linked version of ToxAV.
+ */
++ (NSUInteger)versionMajor;
+
+/**
+ * Return the minor version number of the library
+ */
++ (NSUInteger)versionMinor;
+
+/**
+ * Return the patch number of the library.
+ */
++ (NSUInteger)versionPatch;
+
+/**
+ * Checks if the compiled library version is compatible with
+ * the passed version numbers.
+ * @return YES if compatible, otherwise NO.
+ */
++ (BOOL)versionIsCompatibleWith:(NSUInteger)major minor:(NSUInteger)minor patch:(NSUInteger)patch;
+
+#pragma mark -  Lifecycle
+
+/**
+ * Creates a new Toxav object.
+ * @param tox Tox object to be initialized with.
+ * @param error If an error occurs, this pointer is set to an actual error object.
+ */
+- (instancetype)initWithTox:(OCTTox *)tox error:(NSError **)error;
+
+#pragma mark - Call Methods
+
+/**
+ * Call a friend. This will start ringing the friend.
+ * It is the client's responsibility to stop ringing after a certain timeout,
+ * if such behaviour is desired. If the client does not stop ringing, the
+ * library will not stop until the friend is disconnected.
+ * @param friendNumber The friend number of the friend that should be called.
+ * @param audioBitRate Audio bit rate in Kb/sec. Set this to 0 to disable audio sending.
+ * @param videoBitRate Video bit rate in Kb/sec. Set this to 0 to disable
+ * video sending.
+ */
+- (BOOL)callFriendNumber:(OCTToxFriendNumber)friendNumber audioBitRate:(OCTToxAVAudioBitRate)audioBitRate videoBitRate:(OCTToxAVVideoBitRate)videoBitRate error:(NSError **)error;
 
 @end

--- a/Classes/Public/Wrapper/OCTToxAVConstants.h
+++ b/Classes/Public/Wrapper/OCTToxAVConstants.h
@@ -1,0 +1,77 @@
+//
+//  OCTToxAVConstants.h
+//  objcTox
+//
+//  Created by Chuong Vu on 6/2/15.
+//  Copyright (c) 2015 dvor. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "OCTToxAVConstants.h"
+
+typedef uint32_t OCTToxAVAudioBitRate;
+typedef uint32_t OCTToxAVVideoBitRate;
+
+extern NSString *const kOCTToxAVErrorDomain;
+
+/*******************************************************************************
+ *
+ * Error Codes
+ *
+ ******************************************************************************/
+
+/**
+ * Error codes for init method.
+ */
+typedef NS_ENUM(NSUInteger, OCTToxAVErrorInitCode) {
+    OCTToxAVErrorInitCodeUnknown,
+    /**
+     * One of the arguments to the function was NULL when it was not expected.
+     */
+    OCTToxAVErrorInitNULL,
+
+    /**
+     * Memory allocation failure while trying to allocate structures required for
+     * the A/V session.
+     */
+    OCTToxAVErrorInitCodeMemoryError,
+
+    /**
+     * Attempted to create a second session for the same Tox instance.
+     */
+    OCTToxAVErrorInitMultiple,
+};
+
+/**
+ * Error codes for call setup.
+ */
+typedef NS_ENUM(NSUInteger, OCTToxAVErrorCall) {
+    OCTToxAVErrorCallUnknown,
+
+    /**
+     * A resource allocation error occurred while trying to create the structures
+     * required for the call.
+     */
+    OCTToxAVErrorCallMalloc,
+
+    /**
+     * The friend number did not designate a valid friend.
+     */
+    OCTToxAVErrorCallFriendNotFound,
+
+    /**
+     * The friend was valid, but not currently connected.
+     */
+    OCTToxAVErrorCallFriendNotConnected,
+
+    /**
+     * Attempted to call a friend while already in an audio or video call with
+     * them.
+     */
+    OCTToxAVErrorCallAlreadyInCall,
+
+    /**
+     * Audio or video bit rate is invalid.
+     */
+    OCTToxAVErrorCallInvalidBitRate,
+};

--- a/Classes/Public/Wrapper/OCTToxAVConstants.h
+++ b/Classes/Public/Wrapper/OCTToxAVConstants.h
@@ -10,7 +10,16 @@
 #import "OCTToxAVConstants.h"
 
 typedef uint32_t OCTToxAVAudioBitRate;
+typedef const int16_t OCTToxAVPCMData;
+typedef size_t OCTToxAVSampleCount;
+typedef uint8_t OCTToxAVChannels;
+typedef uint32_t OCTToxAVSampleRate;
+
 typedef uint32_t OCTToxAVVideoBitRate;
+typedef uint16_t OCTToxAVVideoWidth;
+typedef uint16_t OCTToxAVVideoHeight;
+typedef const uint8_t OCTToxAVPlaneData;
+typedef const int32_t OCTToxAVStrideData;
 
 extern NSString *const kOCTToxAVErrorDomain;
 

--- a/Classes/Public/Wrapper/OCTToxAVConstants.h
+++ b/Classes/Public/Wrapper/OCTToxAVConstants.h
@@ -21,6 +21,8 @@ typedef uint16_t OCTToxAVVideoHeight;
 typedef const uint8_t OCTToxAVPlaneData;
 typedef const int32_t OCTToxAVStrideData;
 
+extern const OCTToxAVAudioBitRate kOCTToxAVAudioBitRateDisable;
+extern const OCTToxAVVideoBitRate kOCTToxAVVideoBitRateDisable;
 extern NSString *const kOCTToxAVErrorDomain;
 
 /*******************************************************************************

--- a/objcTox.xcodeproj/project.pbxproj
+++ b/objcTox.xcodeproj/project.pbxproj
@@ -996,6 +996,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				"OTHER_LDFLAGS[arch=*]" = (
+					"-read_only_relocs",
+					suppress,
+				);
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -1095,6 +1099,10 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				"OTHER_LDFLAGS[arch=*]" = (
+					"-read_only_relocs",
+					suppress,
+				);
 				SDKROOT = iphoneos;
 			};
 			name = Debug;

--- a/objcTox.xcodeproj/project.pbxproj
+++ b/objcTox.xcodeproj/project.pbxproj
@@ -120,6 +120,9 @@
 		EE0FB021193E20E6903390EA84A70DAC /* OCTCall.m in Sources */ = {isa = PBXBuildFile; fileRef = A4211DF078AC723DE235503AD4D0E591 /* OCTCall.m */; };
 		EE9A84F0183CA4D0C3342BD50E2F44E5 /* OCTMessageAbstract.m in Sources */ = {isa = PBXBuildFile; fileRef = 5309FB4CA1007014A575D75CB9387C5C /* OCTMessageAbstract.m */; };
 		EF084F94290314128486E23E3CE9B22F /* OCTToxAV.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA03E67FB19C7268351D5CDA3ABCAD3 /* OCTToxAV.m */; };
+		F07C8F991B1E37D300E399F5 /* OCTToxAVConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = F07C8F981B1E37D300E399F5 /* OCTToxAVConstants.m */; };
+		F07C8F9A1B1E37D300E399F5 /* OCTToxAVConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = F07C8F981B1E37D300E399F5 /* OCTToxAVConstants.m */; };
+		F07C8F9E1B1E444300E399F5 /* OCTToxAVTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F07C8F9D1B1E444300E399F5 /* OCTToxAVTests.m */; };
 		F09E0C2F1B18475F00C25A24 /* OCTCallSubmanager.m in Sources */ = {isa = PBXBuildFile; fileRef = F09E0C2E1B18475F00C25A24 /* OCTCallSubmanager.m */; };
 		F0A6B9191B127EA700E48797 /* OCTAudioEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A6B9181B127EA700E48797 /* OCTAudioEngine.m */; };
 		F0E77FC11B154F6000434A96 /* OCTAudioEngineTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F0E77FC01B154F6000434A96 /* OCTAudioEngineTests.m */; };
@@ -268,6 +271,10 @@
 		E9E579DEF80DD05B8F30CA2822233B2B /* OCTDefaultFileStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCTDefaultFileStorage.m; sourceTree = "<group>"; };
 		EEC5B20DF06F1D3048282D1068C2CE9F /* OCTDBChat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCTDBChat.h; sourceTree = "<group>"; };
 		EEE0165339DE12FD2EE1821ACE3E19B8 /* OCTToxOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCTToxOptions.h; sourceTree = "<group>"; };
+		F07C8F971B1E379D00E399F5 /* OCTToxAVConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCTToxAVConstants.h; sourceTree = "<group>"; };
+		F07C8F981B1E37D300E399F5 /* OCTToxAVConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCTToxAVConstants.m; sourceTree = "<group>"; };
+		F07C8F9D1B1E444300E399F5 /* OCTToxAVTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCTToxAVTests.m; sourceTree = "<group>"; };
+		F07C8F9F1B1E4F7400E399F5 /* OCTTox+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OCTTox+Private.h"; sourceTree = "<group>"; };
 		F09E0C2E1B18475F00C25A24 /* OCTCallSubmanager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCTCallSubmanager.m; sourceTree = "<group>"; };
 		F0A6B9171B127EA700E48797 /* OCTAudioEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OCTAudioEngine.h; path = Audio/OCTAudioEngine.h; sourceTree = "<group>"; };
 		F0A6B9181B127EA700E48797 /* OCTAudioEngine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OCTAudioEngine.m; path = Audio/OCTAudioEngine.m; sourceTree = "<group>"; };
@@ -333,8 +340,10 @@
 			children = (
 				B08EB0152D5B2993766DD654578C3493 /* OCTTox.m */,
 				9DA03E67FB19C7268351D5CDA3ABCAD3 /* OCTToxAV.m */,
-				872468E740CD9DEC5E48ED9646696C62 /* OCTToxConstants.m */,
 				1AED5AE89C3775595A525D3B45B80637 /* OCTToxOptions.m */,
+				872468E740CD9DEC5E48ED9646696C62 /* OCTToxConstants.m */,
+				F07C8F981B1E37D300E399F5 /* OCTToxAVConstants.m */,
+				F07C8F9F1B1E4F7400E399F5 /* OCTTox+Private.h */,
 			);
 			path = Wrapper;
 			sourceTree = "<group>";
@@ -584,6 +593,7 @@
 				00599146A8F90E7F4C08E2580B614046 /* OCTSubmanagerFriendsTests.m */,
 				64EA7BAFA98EE28FB70015BEEE7CD684 /* OCTSubmanagerUserTests.m */,
 				F82F69945781A14E76974FA7A2B9220C /* OCTToxTests.m */,
+				F07C8F9D1B1E444300E399F5 /* OCTToxAVTests.m */,
 				11B4BAF61B11E38A0001A96A /* OCTSubmanagerFilesTests.m */,
 			);
 			path = objcToxTests;
@@ -648,6 +658,7 @@
 				1D66E7C409BC96AC7372B302BABF1D88 /* OCTTox.h */,
 				52F0E8E5DC7D621C1DAF55A9242E03FF /* OCTToxAV.h */,
 				6733F3E1A4E00CC032F25870E9083F13 /* OCTToxConstants.h */,
+				F07C8F971B1E379D00E399F5 /* OCTToxAVConstants.h */,
 				49DADF58900503E712C710CF13F175DD /* OCTToxDelegate.h */,
 				EEE0165339DE12FD2EE1821ACE3E19B8 /* OCTToxOptions.h */,
 			);
@@ -859,6 +870,7 @@
 				D9D0587D1B7D85A0B474FC7872831EA8 /* OCTSubmanagerFriends.m in Sources */,
 				5FB0DDAF63C36E0050A15B56311BD5F7 /* OCTSubmanagerUser.m in Sources */,
 				17447E8C08F7FFAFB783AE0AF4207D7F /* OCTTableViewController.m in Sources */,
+				F07C8F9A1B1E37D300E399F5 /* OCTToxAVConstants.m in Sources */,
 				94F0A37FA0EEEA35BC0EF33D61741340 /* OCTTox.m in Sources */,
 				821638761952C80A02200E519414B52A /* OCTToxAV.m in Sources */,
 				D8F9288BBAFADBB9AA3E0E04A0876917 /* OCTToxConstants.m in Sources */,
@@ -883,6 +895,7 @@
 				049DBD8CE1F268F9EEA793377BA27932 /* OCTConverterChat.m in Sources */,
 				6AE781E46CFF671941F785CD9611E912 /* OCTConverterChatTests.m in Sources */,
 				EA9DF855B773BF8EAE1CC617669E9EC1 /* OCTConverterFriend.m in Sources */,
+				F07C8F991B1E37D300E399F5 /* OCTToxAVConstants.m in Sources */,
 				1A85FA95189B03F6CEABA4D4ADB1723F /* OCTConverterFriendRequest.m in Sources */,
 				888C57E04480581E13D03891BA5A4143 /* OCTConverterFriendRequestTests.m in Sources */,
 				7F6B208C44D7319C97DD12012E9DAB9C /* OCTConverterFriendTests.m in Sources */,
@@ -936,6 +949,7 @@
 				893066FF62015FDCE84BB45658D32643 /* OCTToxConstants.m in Sources */,
 				4E4763F528BBD1BC03942CE5539F6FC7 /* OCTToxOptions.m in Sources */,
 				5FEB6690AA990BAAC797A711582F7B5C /* OCTToxTests.m in Sources */,
+				F07C8F9E1B1E444300E399F5 /* OCTToxAVTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/objcToxTests/OCTToxAVTests.m
+++ b/objcToxTests/OCTToxAVTests.m
@@ -1,0 +1,47 @@
+//
+//  OCTToxAVTests.m
+//  objcTox
+//
+//  Created by Chuong Vu on 6/2/15.
+//  Copyright (c) 2015 dvor. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "OCTToxAV.h"
+#import "OCTTox+Private.h"
+#import "toxav.h"
+
+@interface OCTToxAV (Tests)
+
+- (void)fillError:(NSError **)error withCErrorInit:(TOXAV_ERR_NEW)cError;
+
+@end
+@interface OCTToxAVTests : XCTestCase
+
+@property (strong, nonatomic) OCTToxAV *toxAV;
+
+@end
+
+@implementation OCTToxAVTests
+
+- (void)setUp
+{
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+
+- (void)testFillErrorInit
+{
+
+}
+
+@end

--- a/objcToxTests/OCTToxAVTests.m
+++ b/objcToxTests/OCTToxAVTests.m
@@ -59,11 +59,6 @@
     XCTAssertTrue(error.code == OCTToxAVErrorInitNULL);
 
     error = nil;
-    [self.toxAV fillError:&error withCErrorInit:TOXAV_ERR_NEW_MULTIPLE];
-    XCTAssertNotNil(error);
-    XCTAssertTrue(error.code == OCTToxAVErrorInitMultiple);
-
-    error = nil;
     [self.toxAV fillError:&error withCErrorInit:TOXAV_ERR_NEW_MALLOC];
     XCTAssertNotNil(error);
     XCTAssertTrue(error.code == OCTToxAVErrorInitCodeMemoryError);
@@ -72,7 +67,6 @@
     [self.toxAV fillError:&error withCErrorInit:TOXAV_ERR_NEW_MULTIPLE];
     XCTAssertNotNil(error);
     XCTAssertTrue(error.code == OCTToxAVErrorInitMultiple);
-
 }
 
 - (void)testFillErrorCall

--- a/objcToxTests/OCTToxAVTests.m
+++ b/objcToxTests/OCTToxAVTests.m
@@ -16,11 +16,13 @@
 @interface OCTToxAV (Tests)
 
 - (void)fillError:(NSError **)error withCErrorInit:(TOXAV_ERR_NEW)cError;
+- (void)fillError:(NSError **)error withCErrorCall:(TOXAV_ERR_CALL)cError;
 
 @end
 @interface OCTToxAVTests : XCTestCase
 
 @property (strong, nonatomic) OCTToxAV *toxAV;
+@property (strong, nonatomic) OCTTox *tox;
 
 @end
 
@@ -30,18 +32,77 @@
 {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
+    self.tox = [[OCTTox alloc] initWithOptions:[OCTToxOptions new] savedData:nil error:nil];
+    self.toxAV = [[OCTToxAV alloc] initWithTox:self.tox error:nil];
 }
 
 - (void)tearDown
 {
     // Put teardown code here. This method is called after the invocation of each test method in the class.
+    self.tox = nil;
+    self.toxAV = nil;
     [super tearDown];
 }
 
+- (void)testInit
+{
+    XCTAssertNotNil(self.toxAV);
+}
 
 - (void)testFillErrorInit
 {
+    [self.toxAV fillError:nil withCErrorInit:TOXAV_ERR_NEW_NULL];
 
+    NSError *error;
+    [self.toxAV fillError:&error withCErrorInit:TOXAV_ERR_NEW_NULL];
+    XCTAssertNotNil(error);
+    XCTAssertTrue(error.code == OCTToxAVErrorInitNULL);
+
+    error = nil;
+    [self.toxAV fillError:&error withCErrorInit:TOXAV_ERR_NEW_MULTIPLE];
+    XCTAssertNotNil(error);
+    XCTAssertTrue(error.code == OCTToxAVErrorInitMultiple);
+
+    error = nil;
+    [self.toxAV fillError:&error withCErrorInit:TOXAV_ERR_NEW_MALLOC];
+    XCTAssertNotNil(error);
+    XCTAssertTrue(error.code == OCTToxAVErrorInitCodeMemoryError);
+
+    error = nil;
+    [self.toxAV fillError:&error withCErrorInit:TOXAV_ERR_NEW_MULTIPLE];
+    XCTAssertNotNil(error);
+    XCTAssertTrue(error.code == OCTToxAVErrorInitMultiple);
+
+}
+
+- (void)testFillErrorCall
+{
+    [self.toxAV fillError:nil withCErrorCall:TOXAV_ERR_CALL_MALLOC];
+
+    NSError *error;
+    [self.toxAV fillError:&error withCErrorCall:TOXAV_ERR_CALL_MALLOC];
+    XCTAssertNotNil(error);
+    XCTAssertTrue(error.code == OCTToxAVErrorCallMalloc);
+
+    error = nil;
+    [self.toxAV fillError:&error withCErrorCall:TOXAV_ERR_CALL_FRIEND_NOT_FOUND];
+    XCTAssertNotNil(error);
+    XCTAssertTrue(error.code == OCTToxAVErrorCallFriendNotFound);
+
+    error = nil;
+    [self.toxAV fillError:&error withCErrorCall:TOXAV_ERR_CALL_FRIEND_NOT_CONNECTED];
+    XCTAssertNotNil(error);
+    XCTAssertTrue(error.code == OCTToxAVErrorCallFriendNotConnected);
+
+    error = nil;
+    [self.toxAV fillError:&error withCErrorCall:TOXAV_ERR_CALL_FRIEND_ALREADY_IN_CALL];
+    XCTAssertNotNil(error);
+    XCTAssertTrue(error.code == OCTToxAVErrorCallAlreadyInCall);
+
+    error = nil;
+    [self.toxAV fillError:&error withCErrorCall:TOXAV_ERR_CALL_INVALID_BIT_RATE];
+    XCTAssertNotNil(error);
+    XCTAssertTrue(error.code == OCTToxAVErrorCallInvalidBitRate);
 }
 
 @end


### PR DESCRIPTION
Beginning of the wrappers have been started. For the `start` method, I just copied from OCTTox and replaced everything with ToxAV since I'm not quite sure how dispatching queues work. So if I missed anything let me know :smiley_cat: 
