### PR TITLE
Move call control methods to submanagercalls.

### DIFF
--- a/Classes/Private/Manager/Audio/OCTAudioEngine.m
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.m
@@ -12,7 +12,7 @@
 
 static const AudioUnitElement kInputBus = 1;
 static const AudioUnitElement kOutputBus = 0;
-static const int kBufferLength = 1025;
+static const int kBufferLength = 1024;
 
 @interface OCTAudioEngine ()
 
@@ -253,7 +253,7 @@ static OSStatus outputRenderCallBack(void *inRefCon,
     AudioStreamBasicDescription asbd = {0};
     asbd.mSampleRate = sampleRate;
     asbd.mFormatID = kAudioFormatLinearPCM;
-    asbd.mFormatFlags = kAudioFormatFlagIsFloat | kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsPacked | kAudioFormatFlagIsNonInterleaved;
+    asbd.mFormatFlags = kLinearPCMFormatFlagIsSignedInteger;
     asbd.mChannelsPerFrame = 2;
     asbd.mBytesPerFrame = bytesPerSample;
     asbd.mBitsPerChannel = 8 * bytesPerSample;

--- a/Classes/Private/Manager/Objects/OCTCall+Private.h
+++ b/Classes/Private/Manager/Objects/OCTCall+Private.h
@@ -12,4 +12,6 @@
 
 - (instancetype)initWithChat:(OCTChat *)chat friend:(OCTFriend *)friend;
 
+@property (nonatomic, assign, readwrite) OCTCallStatus status;
+
 @end

--- a/Classes/Private/Manager/Objects/OCTCall+Private.h
+++ b/Classes/Private/Manager/Objects/OCTCall+Private.h
@@ -1,0 +1,15 @@
+//
+//  OCTCall+Private.h
+//  objcTox
+//
+//  Created by Chuong Vu on 6/6/15.
+//  Copyright (c) 2015 dvor. All rights reserved.
+//
+
+#import "OCTCall.h"
+
+@interface OCTCall (Private)
+
+- (instancetype)initWithChat:(OCTChat *)chat friend:(OCTFriend *)friend;
+
+@end

--- a/Classes/Private/Manager/Objects/OCTCall.m
+++ b/Classes/Private/Manager/Objects/OCTCall.m
@@ -26,7 +26,6 @@
 
     _chatSession = chat;
     _caller = friend;
-    _status = OCTCallStatusInActive;
 
     return self;
 }

--- a/Classes/Private/Manager/Objects/OCTCall.m
+++ b/Classes/Private/Manager/Objects/OCTCall.m
@@ -7,38 +7,28 @@
 //
 
 #import "OCTCall.h"
+#import "OCTAudioEngine.h"
+#import "OCTToxAV.h"
+
+@interface OCTCall ()
+
+@end
 
 @implementation OCTCall
 
-- (BOOL)togglePauseCall:(BOOL)pause error:(NSError **)error
+- (instancetype)initWithChat:(OCTChat *)chat friend:(OCTFriend *)friend
 {
-    return NO;
+    self = [super init];
+
+    if (! self) {
+        return nil;
+    }
+
+    _chatSession = chat;
+    _caller = friend;
+    _status = OCTCallStatusInActive;
+
+    return self;
 }
 
-- (BOOL)togglePauseVideo:(BOOL)pause error:(NSError **)error
-{
-    return NO;
-}
-
-- (BOOL)endCall:(NSError **)error
-{
-    return NO;
-}
-
-- (BOOL)toggleMuteCall:(BOOL)mute error:(NSError **)error
-{
-    return NO;
-}
-
-- (UIView *)videoFeed
-{
-    return nil;
-}
-
-
-- (void)setAudioBitrate:(int)bitrate
-{}
-
-- (void)setVideoBitrate:(int)bitrate
-{}
 @end

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
@@ -8,10 +8,12 @@
 
 #import "OCTSubmanagerCalls+Private.h"
 #import "OCTToxAV.h"
+#import "OCTAudioEngine.h"
 
-@interface OCTSubmanagerCalls ()
+@interface OCTSubmanagerCalls () <OCTToxAVDelegate>
 
 @property (strong, nonatomic) OCTToxAV *toxAV;
+@property (strong, nonatomic) OCTAudioEngine *audioEngine;
 
 @end
 
@@ -26,6 +28,7 @@
     }
 
     _toxAV = [[OCTToxAV alloc] initWithTox:tox error:nil];
+    _toxAV.delegate = self;
 
     return self;
 }
@@ -39,5 +42,43 @@
 {
     return NO;
 }
+
+- (BOOL)togglePause:(BOOL)pause forCall:(OCTCall *)call error:(NSError **)error
+{
+    return NO;
+}
+
+- (BOOL)endCall:(OCTCall *)call error:(NSError **)error
+{
+    return NO;
+}
+
+- (BOOL)toggleMute:(BOOL)mute forCall:(OCTCall *)call error:(NSError **)error
+{
+    return NO;
+}
+
+- (BOOL)togglePauseVideo:(BOOL)pause forCall:(OCTCall *)call error:(NSError **)error
+{
+    return NO;
+}
+
+- (UIView *)videoFeed
+{
+    return nil;
+}
+
+- (void)setAudioBitrate:(int)bitrate forCall:(OCTCall *)call error:(NSError **)error
+{
+    // To Do
+}
+
+- (void)setVideoBitrate:(int)bitrate forCall:(OCTCall *)call error:(NSError **)error
+{
+    // To Do
+}
+
+#pragma mark OCTToxAV delegate methods
+
 
 @end

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
@@ -63,7 +63,7 @@
     return NO;
 }
 
-- (UIView *)videoFeed
+- (UIView *)videoFeedForCall:(OCTCall *)call
 {
     return nil;
 }

--- a/Classes/Public/Manager/Objects/OCTCall.h
+++ b/Classes/Public/Manager/Objects/OCTCall.h
@@ -12,9 +12,9 @@
 #import "OCTFriend.h"
 
 typedef NS_ENUM(NSUInteger, OCTCallStatus) {
+    OCTCallStatusInactive = 0,
     OCTCallStatusPaused,
     OCTCallStatusActive,
-    OCTCallStatusInActive
 };
 
 @interface OCTCall : NSObject
@@ -32,6 +32,6 @@ typedef NS_ENUM(NSUInteger, OCTCallStatus) {
 /**
  * Call status
  **/
-@property (nonatomic, assign) OCTCallStatus status;
+@property (nonatomic, assign, readonly) OCTCallStatus status;
 
 @end

--- a/Classes/Public/Manager/Objects/OCTCall.h
+++ b/Classes/Public/Manager/Objects/OCTCall.h
@@ -11,6 +11,12 @@
 #import "OCTChat.h"
 #import "OCTFriend.h"
 
+typedef NS_ENUM(NSUInteger, OCTCallStatus) {
+    OCTCallStatusPaused,
+    OCTCallStatusActive,
+    OCTCallStatusInActive
+};
+
 @interface OCTCall : NSObject
 
 /**
@@ -24,50 +30,8 @@
 @property (strong, nonatomic, readonly) OCTFriend *caller;
 
 /**
- * Pause the call
- * @param pause YES to pause, NO otherwise.
- * @return YES if successful, NO otherwise.
+ * Call status
  **/
-- (BOOL)togglePauseCall:(BOOL)pause error:(NSError **)error;
-
-/**
- * End the call. Call be ringing or in session.
- * @param error Pointer to error object if there's an issue with ending the call.
- * @return YES if successful, no otherwise.
- **/
-- (BOOL)endCall:(NSError **)error;
-
-/**
- * Mutes the call
- * @param mute YES to mute, NO otherwise.
- * @param error Pointer to error object if there's an issue muting the call.
- * @return YES if successful, NO otherwise.
- **/
-- (BOOL)toggleMuteCall:(BOOL)mute error:(NSError **)error;
-
-/**
- * Toggle turning off or on the video feed
- * @param pause YES to stop the video, NO otherwise to continue.
- * @param error Pointer to error object if there's an issue pausing the video.
- * @return YES if successful, NO otherwise.
- **/
-- (BOOL)togglePauseVideo:(BOOL)pause error:(NSError **)error;
-
-/**
- * The UIView that will have the video feed.
- * @return UIView of the video feed. Nil if no video available.
- **/
-- (UIView *)videoFeed;
-
-
-/**
- * Set the Audio bit rate.
- */
-- (void)setAudioBitrate:(int)bitrate;
-
-/**
- * Set the Video bit rate.
- */
-- (void)setVideoBitrate:(int)bitrate;
+@property (nonatomic, assign) OCTCallStatus status;
 
 @end

--- a/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
+++ b/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
@@ -85,9 +85,10 @@
 
 /**
  * The UIView that will have the video feed.
+ * @param call The call that has the video feed.
  * @return UIView of the video feed. Nil if no video available.
  **/
-- (UIView *)videoFeed;
+- (UIView *)videoFeedForCall:(OCTCall *)call;
 
 /**
  * Set the Audio bit rate.

--- a/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
+++ b/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
@@ -49,4 +49,53 @@
  **/
 - (BOOL)answerCall:(OCTCall *)call enableAudio:(BOOL)enableAudio enableVideo:(BOOL)enableVideo error:(NSError **)error;
 
+/**
+ * Pause the call
+ * @param pause YES to pause, NO otherwise.
+ * @call The appropriate OCTCall to pause
+ * @return YES if successful, NO otherwise.
+ **/
+- (BOOL)togglePause:(BOOL)pause forCall:(OCTCall *)call error:(NSError **)error;
+
+/**
+ * End the call. Call can be ringing or in session.
+ * @call The call to end.
+ * @param error Pointer to error object if there's an issue with ending the call.
+ * @return YES if successful, no otherwise.
+ **/
+- (BOOL)endCall:(OCTCall *)call error:(NSError **)error;
+
+/**
+ * Mutes the call
+ * @param mute YES to mute, NO otherwise.
+ * @param call Call to mute.
+ * @param error Pointer to error object if there's an issue muting the call.
+ * @return YES if successful, NO otherwise.
+ **/
+- (BOOL)toggleMute:(BOOL)mute forCall:(OCTCall *)call error:(NSError **)error;
+
+/**
+ * Toggle turning off or on the video feed
+ * @param pause YES to stop the video, NO otherwise to continue.
+ * @call Call to pause video.
+ * @param error Pointer to error object if there's an issue pausing the video.
+ * @return YES if successful, NO otherwise.
+ **/
+- (BOOL)togglePauseVideo:(BOOL)pause forCall:(OCTCall *)call error:(NSError **)error;
+
+/**
+ * The UIView that will have the video feed.
+ * @return UIView of the video feed. Nil if no video available.
+ **/
+- (UIView *)videoFeed;
+
+/**
+ * Set the Audio bit rate.
+ */
+- (void)setAudioBitrate:(int)bitrate forCall:(OCTCall *)call error:(NSError **)error;
+
+/**
+ * Set the Video bit rate.
+ */
+- (void)setVideoBitrate:(int)bitrate forCall:(OCTCall *)call error:(NSError **)error;
 @end

--- a/objcTox.xcodeproj/project.pbxproj
+++ b/objcTox.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		F07C8F9E1B1E444300E399F5 /* OCTToxAVTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F07C8F9D1B1E444300E399F5 /* OCTToxAVTests.m */; };
 		F09E0C2F1B18475F00C25A24 /* OCTSubmanagerCalls.m in Sources */ = {isa = PBXBuildFile; fileRef = F09E0C2E1B18475F00C25A24 /* OCTSubmanagerCalls.m */; };
 		F0A6B9191B127EA700E48797 /* OCTAudioEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A6B9181B127EA700E48797 /* OCTAudioEngine.m */; };
+		F0AC56F61B2509CA0014CAA2 /* OCTCallTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F0AC56F51B2509CA0014CAA2 /* OCTCallTests.m */; };
 		F0CAD9A91B220EB9008FAA62 /* OCTSubmanagerCalls.m in Sources */ = {isa = PBXBuildFile; fileRef = F09E0C2E1B18475F00C25A24 /* OCTSubmanagerCalls.m */; };
 		F0E77FC11B154F6000434A96 /* OCTAudioEngineTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F0E77FC01B154F6000434A96 /* OCTAudioEngineTests.m */; };
 		F7CE5F0C8796000D383A059517E7E00B /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B2F6BF5A5E995453D311094E693CBC02 /* Images.xcassets */; };
@@ -285,6 +286,7 @@
 		F0A6B9171B127EA700E48797 /* OCTAudioEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OCTAudioEngine.h; path = Audio/OCTAudioEngine.h; sourceTree = "<group>"; };
 		F0A6B9181B127EA700E48797 /* OCTAudioEngine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OCTAudioEngine.m; path = Audio/OCTAudioEngine.m; sourceTree = "<group>"; };
 		F0A791871B1F855400F17DBA /* OCTToxAVDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCTToxAVDelegate.h; sourceTree = "<group>"; };
+		F0AC56F51B2509CA0014CAA2 /* OCTCallTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCTCallTests.m; sourceTree = "<group>"; };
 		F0CAD9A81B220810008FAA62 /* OCTToxAV+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OCTToxAV+Private.h"; sourceTree = "<group>"; };
 		F0E77FC01B154F6000434A96 /* OCTAudioEngineTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCTAudioEngineTests.m; sourceTree = "<group>"; };
 		F5174E797B52B59C74ABA4D0D9A95A4A /* OCTConversationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCTConversationViewController.h; sourceTree = "<group>"; };
@@ -608,6 +610,7 @@
 				F07C8F9D1B1E444300E399F5 /* OCTToxAVTests.m */,
 				11B4BAF61B11E38A0001A96A /* OCTSubmanagerFilesTests.m */,
 				F02C04D01B20FB98001025D1 /* OCTSubmanagerCallsTests.m */,
+				F0AC56F51B2509CA0014CAA2 /* OCTCallTests.m */,
 			);
 			path = objcToxTests;
 			sourceTree = "<group>";
@@ -941,6 +944,7 @@
 				8D958DC640D0FA715511B62D6E3C98F5 /* OCTFriendsContainer.m in Sources */,
 				305EDFAE13B8DA7F9B9DC21FCE0C6636 /* OCTFriendsContainerTests.m in Sources */,
 				539D28156841AD45033774F3D7C7F19B /* OCTManager.m in Sources */,
+				F0AC56F61B2509CA0014CAA2 /* OCTCallTests.m in Sources */,
 				50258CB971E2379741E4E7973EE06F76 /* OCTManagerConfiguration.m in Sources */,
 				0B8E8A0EB99B3637B2FDFDD28C33CB42 /* OCTManagerConfigurationTests.m in Sources */,
 				81FD7F91EABF9ECD34A41C4A7F724D2C /* OCTManagerConstants.m in Sources */,

--- a/objcTox.xcodeproj/project.pbxproj
+++ b/objcTox.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 		EEE0165339DE12FD2EE1821ACE3E19B8 /* OCTToxOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCTToxOptions.h; sourceTree = "<group>"; };
 		F02C04CF1B20F7E0001025D1 /* OCTSubmanagerCalls+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OCTSubmanagerCalls+Private.h"; sourceTree = "<group>"; };
 		F02C04D01B20FB98001025D1 /* OCTSubmanagerCallsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCTSubmanagerCallsTests.m; sourceTree = "<group>"; };
+		F069EB901B240BB70084FB53 /* OCTCall+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OCTCall+Private.h"; sourceTree = "<group>"; };
 		F07C8F971B1E379D00E399F5 /* OCTToxAVConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCTToxAVConstants.h; sourceTree = "<group>"; };
 		F07C8F981B1E37D300E399F5 /* OCTToxAVConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCTToxAVConstants.m; sourceTree = "<group>"; };
 		F07C8F9D1B1E444300E399F5 /* OCTToxAVTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCTToxAVTests.m; sourceTree = "<group>"; };
@@ -453,6 +454,7 @@
 		60183FD68841CB45990A4852224E9705 /* Objects */ = {
 			isa = PBXGroup;
 			children = (
+				F069EB901B240BB70084FB53 /* OCTCall+Private.h */,
 				5903C9CE7D4B1B207811088536236785 /* OCTArray+Private.h */,
 				A6ABABAEF2E5AF3C1EBC4AE56CFCA17D /* OCTArray.m */,
 				FFB36DADF1F646206C7EBBADCBB35889 /* OCTBasicContainer.h */,

--- a/objcToxTests/OCTCallTests.m
+++ b/objcToxTests/OCTCallTests.m
@@ -1,0 +1,43 @@
+//
+//  OCTCallTests.m
+//  objcTox
+//
+//  Created by Chuong Vu on 6/7/15.
+//  Copyright (c) 2015 dvor. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "OCTCall+Private.h"
+
+@interface OCTCallTests : XCTestCase
+
+@end
+
+@implementation OCTCallTests
+
+- (void)setUp
+{
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testInit
+{
+    OCTChat *chat = [OCTChat new];
+    OCTFriend *friend = [[OCTFriend alloc] init];
+    OCTCall *call = [[OCTCall alloc] initWithChat:chat friend:friend];
+
+    XCTAssertNotNil(call);
+    XCTAssertEqualObjects(call.chatSession, chat);
+    XCTAssertEqualObjects(call.caller, friend);
+    XCTAssertEqual(call.status, OCTCallStatusInactive);
+}
+
+@end


### PR DESCRIPTION
What do you think about having OCTCall only holding information about the call. I think this will be similar to OCTChat. And if the user needs to manage or end any calls, they will use the sub manager?
