### PR TITLE
Revamp of OCTCall and start implementation of OCTToxAV into Submanager

### DIFF
--- a/Classes/Private/Manager/Audio/OCTAudioEngine.h
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "OCTToxAV.h"
 
 typedef NS_ENUM(NSInteger, OCTAudioScope) {
     OCTInput,
@@ -14,6 +15,10 @@ typedef NS_ENUM(NSInteger, OCTAudioScope) {
 };
 
 @interface OCTAudioEngine : NSObject
+
+@property (weak, nonatomic) OCTToxAV *toxav;
+@property (nonatomic, assign) OCTToxAVSampleRate currentAudioSampleRate;
+@property (nonatomic, assign) OCTToxFriendNumber friendNumber;
 
 /**
  * Starts the Audio Processing Graph.

--- a/Classes/Private/Manager/Audio/OCTAudioEngine.h
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.h
@@ -17,7 +17,6 @@ typedef NS_ENUM(NSInteger, OCTAudioScope) {
 @interface OCTAudioEngine : NSObject
 
 @property (weak, nonatomic) OCTToxAV *toxav;
-@property (nonatomic, assign) OCTToxAVSampleRate currentAudioSampleRate;
 @property (nonatomic, assign) OCTToxFriendNumber friendNumber;
 
 /**

--- a/Classes/Private/Manager/Audio/OCTAudioEngine.m
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.m
@@ -13,6 +13,7 @@
 static const AudioUnitElement kInputBus = 1;
 static const AudioUnitElement kOutputBus = 0;
 static const int kBufferLength = 1024;
+static const int kNumberOfChannels = 2;
 
 OSStatus (*_NewAUGraph)(AUGraph *outGraph);
 OSStatus (*_AUGraphAddNode)(
@@ -54,6 +55,7 @@ OSStatus (*_AudioUnitRender)(AudioUnit inUnit,
 @property (nonatomic, assign) AudioUnit ioUnit;
 @property (nonatomic, assign) AudioComponentDescription ioUnitDescription;
 @property (nonatomic, assign) TPCircularBuffer buffer;
+@property (nonatomic, assign) OCTToxAVSampleRate currentAudioSampleRate;
 
 @end
 
@@ -249,8 +251,8 @@ static OSStatus inputRenderCallBack(void *inRefCon,
 
     [engine.toxav sendAudioFrame:bufferList.mBuffers[1].mData
                      sampleCount:bufferList.mNumberBuffers
-                        channels:2
-                      sampleRate:48000
+                        channels:kNumberOfChannels
+                      sampleRate:engine.currentAudioSampleRate
                         toFriend:engine.friendNumber
                            error:nil];
     return status;
@@ -308,6 +310,8 @@ static OSStatus outputRenderCallBack(void *inRefCon,
 {
     UInt32 bytesPerSample = sizeof(SInt32);
     double sampleRate = [AVAudioSession sharedInstance].sampleRate;
+
+    self.currentAudioSampleRate = sampleRate;
 
     AudioStreamBasicDescription asbd = {0};
     asbd.mSampleRate = sampleRate;

--- a/Classes/Private/Manager/Audio/OCTAudioEngine.m
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.m
@@ -246,7 +246,13 @@ static OSStatus inputRenderCallBack(void *inRefCon,
                                        inBusNumber,
                                        inNumberFrames,
                                        &bufferList);
-    // To Do: Call [OCTToxAV sendAudioFrames...]
+
+    [engine.toxav sendAudioFrame:bufferList.mBuffers[1].mData
+                     sampleCount:bufferList.mNumberBuffers
+                        channels:2
+                      sampleRate:48000
+                        toFriend:engine.friendNumber
+                           error:nil];
     return status;
 }
 

--- a/Classes/Private/Manager/Converters/OCTConverterCall.m
+++ b/Classes/Private/Manager/Converters/OCTConverterCall.m
@@ -27,11 +27,10 @@
 - (id)objectFromRLMObject:(OCTDBCall *)dbCall
 {
     NSParameterAssert(self.converterChat);
-    OCTCall *call = [OCTCall new];
 
     OCTChat *chat = [self.converterChat objectFromRLMObject:dbCall.chat];
 
-    call.chat = chat;
+    OCTCall *call = [[OCTCall alloc] initCallWithChat:chat];
 
     return call;
 }

--- a/Classes/Private/Manager/OCTManager.m
+++ b/Classes/Private/Manager/OCTManager.m
@@ -102,6 +102,7 @@
     _avatars = avatars;
 
     OCTSubmanagerCalls *calls = [[OCTSubmanagerCalls alloc] initWithTox:_tox];
+    calls.dataSource = self;
     _calls = calls;
 
     _toxSaveFileLock = [NSObject new];

--- a/Classes/Private/Manager/Objects/OCTCall+Private.h
+++ b/Classes/Private/Manager/Objects/OCTCall+Private.h
@@ -12,7 +12,10 @@
 
 - (instancetype)initCallWithChat:(OCTChat *)chat;
 
-@property (strong, nonatomic, readwrite) OCTChat *chat;
 @property (nonatomic, assign, readwrite) OCTCallStatus status;
+@property (strong, nonatomic) NSDate *callStartTime;
+
+- (void)startTimer;
+- (NSTimeInterval)stopTimer;
 
 @end

--- a/Classes/Private/Manager/Objects/OCTCall.m
+++ b/Classes/Private/Manager/Objects/OCTCall.m
@@ -14,6 +14,7 @@
 
 @property (strong, nonatomic, readwrite) OCTChat *chat;
 @property (nonatomic, assign, readwrite) OCTCallStatus status;
+@property (strong, nonatomic) NSDate *callStartTime;
 
 @end
 
@@ -32,4 +33,33 @@
     return self;
 }
 
+- (BOOL)isEqual:(id)object
+{
+    if (self == object) {
+        return YES;
+    }
+
+    if (! [object isKindOfClass:[OCTCall class]]) {
+        return NO;
+    }
+
+    OCTCall *otherCall = object;
+
+    return (self.chat.uniqueIdentifier == otherCall.chat.uniqueIdentifier);
+}
+
+- (NSUInteger)hash
+{
+    return [self.chat.uniqueIdentifier hash];
+}
+
+- (void)startTimer
+{
+    self.callStartTime = [[NSDate alloc] init];
+}
+
+- (NSTimeInterval)stopTimer
+{
+    return [self.callStartTime timeIntervalSinceNow];
+}
 @end

--- a/Classes/Private/Manager/Objects/OCTCall.m
+++ b/Classes/Private/Manager/Objects/OCTCall.m
@@ -14,7 +14,6 @@
 
 @property (strong, nonatomic, readwrite) OCTChat *chat;
 @property (nonatomic, assign, readwrite) OCTCallStatus status;
-@property (strong, nonatomic) NSDate *callStartTime;
 
 @end
 
@@ -54,12 +53,10 @@
 }
 
 - (void)startTimer
-{
-    self.callStartTime = [[NSDate alloc] init];
-}
+{  }
 
 - (NSTimeInterval)stopTimer
 {
-    return [self.callStartTime timeIntervalSinceNow];
+    return 0;
 }
 @end

--- a/Classes/Private/Manager/Objects/OCTChat+Private.h
+++ b/Classes/Private/Manager/Objects/OCTChat+Private.h
@@ -18,4 +18,7 @@
 @property (copy, nonatomic) void (^enteredTextUpdateBlock)(NSString *enteredText);
 @property (copy, nonatomic) void (^lastReadDateUpdateBlock)(NSDate *lastReadDate);
 
+- (void)startTimer;
+- (NSTimeInterval)stopTimer;
+
 @end

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls+Private.h
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls+Private.h
@@ -7,10 +7,19 @@
 //
 
 #import "OCTSubmanagerCalls.h"
+#import "OCTDBManager.h"
+#import "OCTSubmanagerDataSource.h"
+#import "OCTToxAV.h"
+#import "OCTAudioEngine.h"
+#import "OCTConverterChat.h"
+#import "OCTCall+Private.h"
+#import "OCTArray+Private.h"
 
 @class OCTTox;
 
 @interface OCTSubmanagerCalls (Private)
+
+@property (weak, nonatomic) id<OCTSubmanagerDataSource> dataSource;
 
 /**
  * Initialize the OCTSubmanagerCall

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
@@ -7,13 +7,15 @@
 //
 
 #import "OCTSubmanagerCalls+Private.h"
-#import "OCTToxAV.h"
-#import "OCTAudioEngine.h"
 
 @interface OCTSubmanagerCalls () <OCTToxAVDelegate>
 
+@property (weak, nonatomic) id<OCTSubmanagerDataSource> dataSource;
+
 @property (strong, nonatomic) OCTToxAV *toxAV;
 @property (strong, nonatomic) OCTAudioEngine *audioEngine;
+@property (strong, nonatomic) OCTConverterChat *chatConverter;
+@property (strong, nonatomic) NSMutableSet *mutableCalls;
 
 @end
 
@@ -30,12 +32,40 @@
     _toxAV = [[OCTToxAV alloc] initWithTox:tox error:nil];
     _toxAV.delegate = self;
 
+    _audioEngine = [OCTAudioEngine new];
+    _audioEngine.toxav = self.toxAV;
+
+    _chatConverter = [OCTConverterChat new];
+
+    _mutableCalls = [NSMutableSet new];
+
     return self;
+}
+
+- (NSSet *)calls
+{
+    return [self.mutableCalls copy];
 }
 
 - (OCTCall *)callToChat:(OCTChat *)chat enableAudio:(BOOL)enableAudio enableVideo:(BOOL)enableVideo
 {
-    return nil;
+    OCTToxAVAudioBitRate audioBitRate = (enableAudio) ? 24000 : kOCTToxAVAudioBitRateDisable;
+    OCTToxAVVideoBitRate videoBitRate = (enableVideo) ? 400 : kOCTToxAVVideoBitRateDisable;
+
+    OCTFriend *friend = chat.friends.lastObject;
+    self.audioEngine.friendNumber = friend.friendNumber;
+
+    [self.toxAV callFriendNumber:(OCTToxFriendNumber)friend
+                    audioBitRate:audioBitRate
+                    videoBitRate:videoBitRate
+                           error:nil];
+
+    OCTCall *call = [[OCTCall alloc] initCallWithChat:chat];
+    call.status = OCTCallStatusDialing;
+
+    [self.mutableCalls addObject:call];
+
+    return call;
 }
 
 - (BOOL)answerCall:(OCTCall *)call enableAudio:(BOOL)enableAudio enableVideo:(BOOL)enableVideo error:(NSError **)error
@@ -45,12 +75,19 @@
 
 - (BOOL)togglePause:(BOOL)pause forCall:(OCTCall *)call error:(NSError **)error
 {
-    return NO;
+    OCTToxAVCallControl control = (pause) ? OCTToxAVCallControlPause : OCTToxAVCallControlResume;
+    call.status = (pause) ? OCTCallStatusPaused : OCTCallStatusActive;
+
+    OCTFriend *friend = call.chat.friends.firstObject;
+    return [self.toxAV sendCallControl:control toFriendNumber:friend.friendNumber error:error];
 }
 
 - (BOOL)endCall:(OCTCall *)call error:(NSError **)error
 {
-    return NO;
+    OCTFriend *friend = call.chat.friends.firstObject;
+    [self.mutableCalls removeObject:call];
+
+    return [self.toxAV sendCallControl:OCTToxAVCallControlCancel toFriendNumber:friend.friendNumber error:error];
 }
 
 - (BOOL)toggleMute:(BOOL)mute forCall:(OCTCall *)call error:(NSError **)error
@@ -78,7 +115,52 @@
     // To Do
 }
 
+#pragma mark Private methods
+
+
 #pragma mark OCTToxAV delegate methods
+
+- (void)toxAV:(OCTToxAV *)toxAV receiveCallAudioEnabled:(BOOL)audio videoEnabled:(BOOL)video friendNumber:(OCTToxFriendNumber)friendNumber
+{
+    OCTDBManager *dbManager = [self.dataSource managerGetDBManager];
+    OCTDBChat *chatDB = [dbManager getOrCreateChatWithFriendNumber:friendNumber];
+    OCTChat *chat = [self.chatConverter objectFromRLMObject:chatDB];
+
+    OCTCall *call = [[OCTCall alloc] initCallWithChat:chat];
+    call.status = OCTCallStatusIncoming;
+
+    [self.mutableCalls addObject:call];
+
+    [self.delegate callSubmanager:self receiveCall:call audioEnabled:audio videoEnabled:video];
+}
+
+- (void)toxAV:(OCTToxAV *)toxAV callStateChanged:(OCTToxAVCallState)state friendNumber:(OCTToxFriendNumber)friendNumber
+{}
+
+- (void)toxAV:(OCTToxAV *)toxAV audioBitRateChanged:(OCTToxAVAudioBitRate)bitrate stable:(BOOL)stable friendNumber:(OCTToxFriendNumber)friendNumber
+{}
+
+- (void)toxAV:(OCTToxAV *)toxAV videoBitRateChanged:(OCTToxAVVideoBitRate)bitrate friendNumber:(OCTToxFriendNumber)friendNumber stable:(BOOL)stable
+{}
+
+- (void)   toxAV:(OCTToxAV *)toxAV
+    receiveAudio:(OCTToxAVPCMData *)pcm
+     sampleCount:(OCTToxAVSampleCount)sampleCount
+        channels:(OCTToxAVChannels)channels
+      sampleRate:(OCTToxAVSampleRate)sampleRate
+    friendNumber:(OCTToxFriendNumber)friendNumber
+{
+    [self.audioEngine provideAudioFrames:pcm sampleCount:sampleCount channels:channels sampleRate:sampleRate];
+}
+
+- (void)                 toxAV:(OCTToxAV *)toxAV
+    receiveVideoFrameWithWidth:(OCTToxAVVideoWidth)width height:(OCTToxAVVideoHeight)height
+                        yPlane:(OCTToxAVPlaneData *)yPlane uPlane:(OCTToxAVPlaneData *)uPlane
+                        vPlane:(OCTToxAVPlaneData *)vPlane aPlane:(OCTToxAVPlaneData *)aPlane
+                       yStride:(OCTToxAVStrideData)yStride uStride:(OCTToxAVStrideData)uStride
+                       vStride:(OCTToxAVStrideData)vStride aStride:(OCTToxAVStrideData)aStride
+                  friendNumber:(OCTToxFriendNumber)friendNumber
+{}
 
 
 @end

--- a/Classes/Public/Manager/Objects/OCTCall.h
+++ b/Classes/Public/Manager/Objects/OCTCall.h
@@ -7,12 +7,13 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 #import "OCTChat.h"
 #import "OCTFriend.h"
 
 typedef NS_ENUM(NSUInteger, OCTCallStatus) {
     OCTCallStatusInactive = 0,
+    OCTCallStatusDialing,
+    OCTCallStatusIncoming,
     OCTCallStatusPaused,
     OCTCallStatusActive,
 };

--- a/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
+++ b/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
@@ -7,12 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
-#include "OCTChat.h"
-#include "OCTCall.h"
-#include "OCTArray.h"
-
+#import <UIKit/UIKit.h>
+#import "OCTChat.h"
+#import "OCTArray.h"
 @class OCTSubmanagerCalls;
 @class OCTToxAV;
+@class OCTCall;
 
 @protocol OCTSubmanagerCallDelegate <NSObject>
 
@@ -25,10 +25,13 @@
 
 @interface OCTSubmanagerCalls : NSObject
 
+@property (weak, nonatomic) id<OCTSubmanagerCallDelegate> delegate;
+
 /**
  * Call sessions that are active.
  */
-@property (strong, nonatomic, readonly) OCTArray *calls;
+- (NSSet *)calls;
+
 /**
  * This class is responsible for telling the end-user what calls we have available.
  * We can also initialize a call session from here.

--- a/objcTox.xcodeproj/project.pbxproj
+++ b/objcTox.xcodeproj/project.pbxproj
@@ -124,6 +124,8 @@
 		F03FA9511B26807300930CF1 /* OCTDBCall.m in Sources */ = {isa = PBXBuildFile; fileRef = F03FA9501B26807300930CF1 /* OCTDBCall.m */; };
 		F03FA9551B26840D00930CF1 /* OCTConverterCall.m in Sources */ = {isa = PBXBuildFile; fileRef = F03FA9541B26840D00930CF1 /* OCTConverterCall.m */; };
 		F03FA9571B26915200930CF1 /* OCTConverterCallTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F03FA9561B26915200930CF1 /* OCTConverterCallTests.m */; };
+		F06673F31B27BA5F00CBEC25 /* OCTAudioEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A6B9181B127EA700E48797 /* OCTAudioEngine.m */; };
+		F06673F41B27BA6200CBEC25 /* OCTConverterCall.m in Sources */ = {isa = PBXBuildFile; fileRef = F03FA9541B26840D00930CF1 /* OCTConverterCall.m */; };
 		F06C3D391B26AA440023C384 /* OCTDBCall.m in Sources */ = {isa = PBXBuildFile; fileRef = F03FA9501B26807300930CF1 /* OCTDBCall.m */; };
 		F07C8F991B1E37D300E399F5 /* OCTToxAVConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = F07C8F981B1E37D300E399F5 /* OCTToxAVConstants.m */; };
 		F07C8F9A1B1E37D300E399F5 /* OCTToxAVConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = F07C8F981B1E37D300E399F5 /* OCTToxAVConstants.m */; };
@@ -863,6 +865,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F06673F41B27BA6200CBEC25 /* OCTConverterCall.m in Sources */,
+				F06673F31B27BA5F00CBEC25 /* OCTAudioEngine.m in Sources */,
 				F06C3D391B26AA440023C384 /* OCTDBCall.m in Sources */,
 				F0CAD9A91B220EB9008FAA62 /* OCTSubmanagerCalls.m in Sources */,
 				4CD198EE0026B99EA22137D5D0B3B7E3 /* AppDelegate.m in Sources */,

--- a/objcToxTests/OCTCallTests.m
+++ b/objcToxTests/OCTCallTests.m
@@ -33,9 +33,28 @@
     OCTChat *chat = [OCTChat new];
     OCTCall *call = [[OCTCall alloc] initCallWithChat:chat];
 
+
     XCTAssertNotNil(call);
     XCTAssertEqualObjects(call.chat, chat);
     XCTAssertEqual(call.status, OCTCallStatusInactive);
+
+    OCTCall *call2 = [[OCTCall alloc] initCallWithChat:chat];
+    XCTAssertEqualObjects(call2, call);
+
+    OCTChat *chat2 = [OCTChat new];
+    OCTCall *call3 = [[OCTCall alloc] initCallWithChat:chat2];
+
+    XCTAssertFalse(call3 == call);
+}
+
+- (void)testTimer
+{
+    OCTChat *chat = [OCTChat new];
+    OCTCall *call = [[OCTCall alloc] initCallWithChat:chat];
+
+    XCTAssertNil(call.callStartTime);
+    [call startTimer];
+    XCTAssertNotNil(call.callStartTime);
 }
 
 @end

--- a/objcToxTests/OCTCallTests.m
+++ b/objcToxTests/OCTCallTests.m
@@ -47,14 +47,4 @@
     XCTAssertFalse(call3 == call);
 }
 
-- (void)testTimer
-{
-    OCTChat *chat = [OCTChat new];
-    OCTCall *call = [[OCTCall alloc] initCallWithChat:chat];
-
-    XCTAssertNil(call.callStartTime);
-    [call startTimer];
-    XCTAssertNotNil(call.callStartTime);
-}
-
 @end


### PR DESCRIPTION
Halfway through I realized that we could implement `OCTSubmanagerCalls` without the use of `OCTDBCall`. What's important however, is that we need to capture the call duration through `OCTMessageAbstract`, which hasn't been implemented yet.

Let me know what you think..If the above sounds good, I can start removing `OCTDBCall`.

Thanks
