### PR TITLE
Update Cocoapods to 0.35.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: objective-c
 
 before_install:
+    - gem install cocoapods -v '0.35.0'
     - gem install slather -N
     - brew update
     - brew unlink xctool


### PR DESCRIPTION
Travis is complaining about which is causing #31 and #32 from not passing.

The `master` repo requires CocoaPods 0.35.0 -  (currently using 0.34.4)
Update CocoaPods, or checkout the appropriate tag in the repo.
The command "pod install" failed and exited with 1 during .
