### PR TITLE
Improve call handling

### DIFF
--- a/Classes/Private/Manager/Audio/OCTAudioEngine.h
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.h
@@ -15,15 +15,17 @@
 @property (nonatomic, assign) OCTToxFriendNumber friendNumber;
 
 /**
- * YES to not send audio frames over to tox, otherwise No.
+ * YES to send audio frames over to tox, otherwise NO.
+ * Default is YES.
  */
 @property (nonatomic, assign) BOOL enableMicrophone;
 
 /**
- * Default initializer.
+ * Setup must be called once before using the audio engine.
  * @param error Pointer to error object.
- */
-- (instancetype)init:(NSError **)error;
+ * @return YES on success, otherwise NO.
+ **/
+- (BOOL)setupWithError:(NSError **)error;
 
 /**
  * Starts the Audio Processing Graph.

--- a/Classes/Private/Manager/Audio/OCTAudioEngine.h
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.h
@@ -20,6 +20,12 @@ typedef NS_ENUM(NSInteger, OCTAudioScope) {
 @property (nonatomic, assign) OCTToxFriendNumber friendNumber;
 
 /**
+ * Default initializer.
+ * @param error Pointer to error object.
+ */
+- (instancetype)init:(NSError **)error;
+
+/**
  * Starts the Audio Processing Graph.
  * @param error Pointer to error object.
  * @return YES on success, otherwise NO.
@@ -32,15 +38,6 @@ typedef NS_ENUM(NSInteger, OCTAudioScope) {
  * @return YES on success, otherwise NO.
  */
 - (BOOL)stopAudioFlow:(NSError **)error;
-
-/**
- * Enable or disable either output (speaker) or input (microphone).
- * @param scope AudioUnitScope
- * @param enable YES to enable, NO otherwise.
- * @param error Pointer to error object
- * @return YES on success, no otherwise.
- */
-- (BOOL)changeScope:(OCTAudioScope)scope enable:(BOOL)enable error:(NSError **)error;
 
 /**
  * Checks if the Audio Graph is processing.

--- a/Classes/Private/Manager/Audio/OCTAudioEngine.h
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.h
@@ -9,15 +9,15 @@
 #import <Foundation/Foundation.h>
 #import "OCTToxAV.h"
 
-typedef NS_ENUM(NSInteger, OCTAudioScope) {
-    OCTInput,
-    OCTOutput,
-};
-
 @interface OCTAudioEngine : NSObject
 
 @property (weak, nonatomic) OCTToxAV *toxav;
 @property (nonatomic, assign) OCTToxFriendNumber friendNumber;
+
+/**
+ * YES to not send audio frames over to tox, otherwise No.
+ */
+@property (nonatomic, assign) BOOL enableMicrophone;
 
 /**
  * Default initializer.

--- a/Classes/Private/Manager/Audio/OCTAudioEngine.m
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.m
@@ -105,7 +105,7 @@ OSStatus (*_AudioUnitRender)(AudioUnit inUnit,
 
 - (BOOL)setupWithError:(NSError **)error
 {
-    static BOOL status;
+    __block BOOL status = NO;
     dispatch_once(&_setupOnceToken, ^{
         status = ([self enableInputScope:error] &&
                   [self registerInputCallBack:error] &&

--- a/Classes/Private/Manager/Audio/OCTAudioEngine.m
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.m
@@ -169,7 +169,7 @@ OSStatus (*_AudioUnitRender)(AudioUnit inUnit,
     int32_t len = (int32_t)(channels * sampleCount * sizeof(int16_t));
 
     TPCircularBufferProduceBytes(&_outputBuffer, pcm, len);
-    if ((self.outputSampleRate != sampleRate) && [self updateoutputSampleRate:sampleRate error:nil]) {
+    if ((self.outputSampleRate != sampleRate) && [self updateOutputSampleRate:sampleRate error:nil]) {
         self.outputSampleRate = sampleRate;
     }
 }

--- a/Classes/Private/Manager/Audio/OCTAudioEngine.m
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.m
@@ -97,6 +97,8 @@ OSStatus (*_AudioUnitRender)(AudioUnit inUnit,
 
     _AUGraphNodeInfo(_processingGraph, _ioNode, NULL, &_ioUnit);
 
+    _enableMicrophone = YES;
+
     if (! ([self enableInputScope:error] &&
            [self registerInputCallBack:error] &&
            [self registerOutputCallBack:error] &&
@@ -226,13 +228,18 @@ static OSStatus inputRenderCallBack(void *inRefCon,
                                     UInt32 inNumberFrames,
                                     AudioBufferList *ioData)
 {
+    OCTAudioEngine *engine = (__bridge OCTAudioEngine *)(inRefCon);
+
+    if (! engine.enableMicrophone) {
+        return noErr;
+    }
+
     AudioBufferList bufferList;
     bufferList.mNumberBuffers = 1;
     bufferList.mBuffers[0].mNumberChannels = kNumberOfChannels;
     bufferList.mBuffers[0].mData = NULL;
     bufferList.mBuffers[0].mDataByteSize = inNumberFrames * sizeof(SInt16) * kNumberOfChannels;
 
-    OCTAudioEngine *engine = (__bridge OCTAudioEngine *)(inRefCon);
     OSStatus status = _AudioUnitRender(engine.ioUnit,
                                        ioActionFlags,
                                        inTimeStamp,

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
@@ -115,6 +115,16 @@ const OCTToxAVAudioBitRate kDefaultVideoBitRate = 400;
     }
 }
 
+- (BOOL)enableMicrophone
+{
+    return self.audioEngine.enableMicrophone;
+}
+
+- (void)setEnableMicrophone:(BOOL)enableMicrophone
+{
+    self.audioEngine.enableMicrophone = enableMicrophone;
+}
+
 - (BOOL)togglePause:(BOOL)pause forCall:(OCTCall *)call error:(NSError **)error
 {
     OCTToxAVCallControl control = (pause) ? OCTToxAVCallControlPause : OCTToxAVCallControlResume;

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
@@ -40,6 +40,7 @@ const OCTToxAVAudioBitRate kDefaultVideoBitRate = 400;
 
     _audioEngine = [OCTAudioEngine new];
     _audioEngine.toxav = self.toxAV;
+    [_audioEngine setupWithError:nil];
 
     OCTConverterFriend *friendConverter = [OCTConverterFriend new];
     friendConverter.dataSource = self;

--- a/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
+++ b/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
@@ -34,6 +34,11 @@
 @property (weak, nonatomic) id<OCTSubmanagerCallDelegate> delegate;
 
 /**
+ * Set the property to YES to enable the microphone, otherwise YES.
+ **/
+@property (nonatomic, assign) BOOL enableMicrophone;
+
+/**
  * All call sessions.
  */
 @property (strong, nonatomic, readonly) OCTCallsContainer *calls;

--- a/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
+++ b/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
@@ -34,7 +34,8 @@
 @property (weak, nonatomic) id<OCTSubmanagerCallDelegate> delegate;
 
 /**
- * Set the property to YES to enable the microphone, otherwise YES.
+ * Set the property to YES to enable the microphone, otherwise NO.
+ * Default value is YES;
  **/
 @property (nonatomic, assign) BOOL enableMicrophone;
 

--- a/objcToxDemo/OCTConversationViewController.m
+++ b/objcToxDemo/OCTConversationViewController.m
@@ -101,6 +101,10 @@
         [sheet bk_addButtonWithTitle:@"End call" handler:^{
             [weakSelf endCall];
         }];
+
+        [sheet bk_addButtonWithTitle:@"Mute/Unmute" handler:^{
+            [weakSelf toggleMuteMic];
+        }];
     }];
 }
 
@@ -142,6 +146,12 @@
         NSLog(@"%@ Error %@", self, error.localizedDescription);
         NSLog(@"%@ Reason: %@", self, error.localizedFailureReason);
     }
+}
+
+- (void)toggleMuteMic
+{
+    BOOL currentStatus = self.manager.calls.enableMicrophone;
+    self.manager.calls.enableMicrophone = ! currentStatus;
 }
 
 @end

--- a/objcToxTests/OCTAudioEngineTests.m
+++ b/objcToxTests/OCTAudioEngineTests.m
@@ -53,7 +53,7 @@ OSStatus mocked_fail_inGraph(AUGraph inGraph);
     OCMStub([self.audioSession setActive:YES error:[OCMArg anyObjectRef]]).andReturn(YES);
     OCMStub([self.audioSession setActive:NO error:[OCMArg anyObjectRef]]).andReturn(YES);
 
-    self.audioEngine = [[OCTAudioEngine alloc] init:nil];
+    self.audioEngine = [[OCTAudioEngine alloc] init];
     // Put setup code here. This method is called before the invocation of each test method in the class.
 }
 

--- a/objcToxTests/OCTAudioEngineTests.m
+++ b/objcToxTests/OCTAudioEngineTests.m
@@ -53,7 +53,7 @@ OSStatus mocked_fail_inGraph(AUGraph inGraph);
     OCMStub([self.audioSession setActive:YES error:[OCMArg anyObjectRef]]).andReturn(YES);
     OCMStub([self.audioSession setActive:NO error:[OCMArg anyObjectRef]]).andReturn(YES);
 
-    self.audioEngine = [OCTAudioEngine new];
+    self.audioEngine = [[OCTAudioEngine alloc] init:nil];
     // Put setup code here. This method is called before the invocation of each test method in the class.
 }
 
@@ -81,11 +81,6 @@ OSStatus mocked_fail_inGraph(AUGraph inGraph);
     _AUGraphStart = mocked_success_inGraph;
     NSError *error;
     XCTAssertTrue([self.audioEngine startAudioFlow:&error]);
-
-    _AUGraphInitialize = mocked_fail_inGraph;
-    XCTAssertFalse([self.audioEngine startAudioFlow:&error]);
-    XCTAssertNotNil(error);
-    XCTAssertEqual(error.code, 1);
 }
 
 - (void)testStopAudioFlow


### PR DESCRIPTION
Builds on top of #42 . Feel free to close the other if you want to review both at the same time. 

This PR improves the call handling. You can call -> end call then call again without having to restart the app. 

Muting the microphone is controlled by a property. Unfortunately the old method did not allow us to mute the scope once the audio unit is initialized.
