### PR TITLE
Chuongv/additional pause logic

### DIFF
--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
@@ -316,6 +316,10 @@ const OCTToxAVAudioBitRate kDefaultVideoBitRate = 400;
     [realmManager updateObject:call withBlock:^(OCTCall *callToUpdate) {
         callToUpdate.status = OCTCallStatusRinging;
         callToUpdate.caller = friend;
+        callToUpdate.sendingAudio = audio;
+        callToUpdate.receivingAudio = audio;
+        callToUpdate.sendingVideo = video;
+        callToUpdate.receivingVideo = video;
     }];
 
     if ([self.delegate respondsToSelector:@selector(callSubmanager:receiveCall:audioEnabled:videoEnabled:)]) {

--- a/Classes/Public/Manager/Objects/OCTCall.h
+++ b/Classes/Public/Manager/Objects/OCTCall.h
@@ -54,6 +54,16 @@
 @property BOOL receivingVideo;
 
 /**
+ * The call is paused by friend.
+ */
+@property BOOL pausedByFriend;
+
+/**
+ * The call is paused by you.
+ */
+@property BOOL pausedByYou;
+
+/**
  * Call duration
  **/
 @property NSTimeInterval callDuration;

--- a/Classes/Public/Wrapper/OCTToxAVConstants.h
+++ b/Classes/Public/Wrapper/OCTToxAVConstants.h
@@ -30,6 +30,12 @@ extern NSString *const kOCTToxAVErrorDomain;
  ******************************************************************************/
 
 typedef NS_OPTIONS(NSInteger, OCTToxAVCallState) {
+
+    /**
+     * The call is paused by the friend.
+     */
+    OCTToxAVFriendCallStatePaused = 0,
+
     /**
      * Set by the AV core if an error occurred on the remote end or if friend
      * timed out. This is the final state after which no more state

--- a/objcToxTests/OCTToxAVTests.m
+++ b/objcToxTests/OCTToxAVTests.m
@@ -138,6 +138,9 @@ OCTToxAVPlaneData *aPlanePointer = aPlaneTestData;
 
     [self.toxAV start];
     [self.toxAV stop];
+
+    _toxav_iterate = nil;
+    _toxav_iteration_interval = nil;
 }
 
 - (void)testSetAudioBitRate


### PR DESCRIPTION
I added 2 extra properties to `OCTCall` so I can keep track of who initiated the pause of the call. In addition it lets me know when I can move call from `OCTCallPause` to `OCTCallActive`. There's probably a better way of improving this so the code could be more readable?
