### PR TITLE
Bux fix #76 Speakerphone is default for audio calls

### DIFF
--- a/Classes/Private/Manager/Audio/OCTAudioEngine.m
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.m
@@ -350,7 +350,7 @@ OSStatus outputRenderCallBack(void *inRefCon,
 
     return ([session setCategory:AVAudioSessionCategoryPlayAndRecord error:error] &&
             [session setPreferredSampleRate:kDefaultSampleRate error:error] &&
-            [session setMode:AVAudioSessionModeVideoChat error:error] &&
+            [session setMode:AVAudioSessionModeVoiceChat error:error] &&
             [session setActive:YES error:error]);
 }
 


### PR DESCRIPTION
This commit changes the AVAudioSession category to VoiceChat.
Fixes https://github.com/Antidote-for-Tox/objcTox/issues/76
