### PR TITLE
Bug fix: stream update for playback

### DIFF
--- a/Classes/Private/Manager/Audio/OCTAudioEngine.m
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.m
@@ -438,7 +438,7 @@ OSStatus outputRenderCallBack(void *inRefCon,
 
 - (BOOL)updateOutputSampleRate:(OCTToxAVSampleRate)rate channels:(OCTToxAVChannels)channels error:(NSError **)error
 {
-    DDLogVerbose(@"%@ updateOutputSampleRate:%ul channels:%ul", self, rate, channels);
+    DDLogVerbose(@"%@ updateOutputSampleRate:%u channels:%u", self, rate, channels);
 
     UInt32 bytesPerSample = sizeof(SInt16);
 
@@ -454,8 +454,8 @@ OSStatus outputRenderCallBack(void *inRefCon,
 
     OSStatus status = _AudioUnitSetProperty(self.ioUnit,
                                             kAudioUnitProperty_StreamFormat,
-                                            kAudioUnitScope_Output,
-                                            kInputBus,
+                                            kAudioUnitScope_Input,
+                                            kOutputBus,
                                             &asbd,
                                             sizeof(asbd));
     if (status != noErr) {

--- a/Classes/Private/Wrapper/OCTToxAV.m
+++ b/Classes/Private/Wrapper/OCTToxAV.m
@@ -223,6 +223,8 @@ bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t w
 
     [self fillError:error withCErrorSetBitRate:cError];
 
+    DDLogVerbose(@"%@: setAudioBitRate:%lu, force:%d, friend:%d", self, bitRate, force, friendNumber);
+
     return status;
 }
 


### PR DESCRIPTION
Big thanks to GrayHatter for helping me troubleshoot this. With this commit, uTox <---> objcTox sound perfect with each other. 

objcTox was updating the input stream whenever a friend is sending
audio with 1 channel. Instead objcTox should be updating the playback stream.
