### PR TITLE
Create video queue for OCTToxAV

### DIFF
--- a/Classes/Private/Wrapper/OCTToxAV+Private.h
+++ b/Classes/Private/Wrapper/OCTToxAV+Private.h
@@ -46,6 +46,7 @@ toxav_video_receive_frame_cb receiveVideoFrameCallback;
 @interface OCTToxAV (Private)
 
 @property (assign, nonatomic) ToxAV *toxAV;
+@property (strong, nonatomic) dispatch_queue_t videoProcessingQueue;
 
 - (BOOL)fillError:(NSError **)error withCErrorInit:(TOXAV_ERR_NEW)cError;
 - (BOOL)fillError:(NSError **)error withCErrorCall:(TOXAV_ERR_CALL)cError;

--- a/objcToxTests/OCTToxAVTests.m
+++ b/objcToxTests/OCTToxAVTests.m
@@ -421,6 +421,8 @@ OCTToxAVPlaneData *aPlanePointer = aPlaneTestData;
     const OCTToxAVPlaneData vPlane[] = {1, 2, 5, 4, 5};
     const OCTToxAVPlaneData *vPointer = vPlane;
 
+    self.toxAV.videoProcessingQueue = dispatch_get_main_queue();
+
     [self makeTestCallbackWithCallBlock:^{
         receiveVideoFrameCallback(NULL, 123,
                                   999, 888,


### PR DESCRIPTION
This alleviates this issue https://github.com/Antidote-for-Tox/Antidote/issues/111. Instead of crashing :100: % of the time, it is now only 10% . I think I should put the audio call backs on the same queue as well?
