### PR TITLE
Add nullability annotations for OCTSubmanagerCalls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,13 @@ notifications:
 before_install:
     - gem install slather -N
     - gem install cocoapods
-    - brew update
-    - brew unlink xctool
-    - brew install xctool
+    # fixing issue with homebrew https://github.com/Homebrew/homebrew/issues/42553
+    - brew update; brew update
     - brew install uncrustify
     - pod install
 
 script:
-    - xctool -workspace objcTox.xcworkspace -scheme objcToxDemo -destination 'platform=iOS Simulator,name=iPhone 6' -sdk iphonesimulator GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean test
+    - xctool -workspace objcTox.xcworkspace -scheme objcToxDemo -sdk iphonesimulator GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean test
     - ./run-uncrustify.sh --check
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: xcode6.4
 
 notifications:
     email:

--- a/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
+++ b/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
@@ -16,7 +16,6 @@
 @class OCTToxAV;
 @class OCTCall;
 
-NS_ASSUME_NONNULL_BEGIN
 @interface OCTSubmanagerCalls : NSObject
 
 @property (nullable, weak, nonatomic) id<OCTSubmanagerCallDelegate> delegate;
@@ -32,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param error Pointer to an error when setting up.
  * @return YES on success, otherwise NO.
  */
-- (BOOL)setupWithError:(NSError **)error;
+- (BOOL)setupWithError:(NSError *__nullable *__nullable)error;
 
 /**
  * This class is responsible for telling the end-user what calls we have available.
@@ -43,7 +42,10 @@ NS_ASSUME_NONNULL_BEGIN
  * @param error Pointer to an error when attempting to answer a call
  * @return OCTCall session
  */
-- (nullable OCTCall *)callToChat:(OCTChat *)chat enableAudio:(BOOL)enableAudio enableVideo:(BOOL)enableVideo error:(NSError **)error;
+- (nullable OCTCall *)callToChat:(nonnull OCTChat *)chat
+                     enableAudio:(BOOL)enableAudio
+                     enableVideo:(BOOL)enableVideo
+                           error:(NSError *__nullable *__nullable)error;
 
 /**
  * Enable video calling for an active call.
@@ -53,7 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @param error Pointer to an error object.
  * @return YES on success, otherwise NO.
  */
-- (BOOL)enableVideoSending:(BOOL)enable forCall:(OCTCall *)call error:(NSError **)error;
+- (BOOL)enableVideoSending:(BOOL)enable
+                   forCall:(nonnull OCTCall *)call
+                     error:(NSError *__nullable *__nullable)error;
 
 /**
  * Answer a call
@@ -63,7 +67,10 @@ NS_ASSUME_NONNULL_BEGIN
  * @param error Pointer to an error when attempting to answer a call
  * @return YES if we were able to succesfully answer the call, otherwise NO.
  */
-- (BOOL)answerCall:(OCTCall *)call enableAudio:(BOOL)enableAudio enableVideo:(BOOL)enableVideo error:(NSError **)error;
+- (BOOL)answerCall:(nonnull OCTCall *)call
+       enableAudio:(BOOL)enableAudio
+       enableVideo:(BOOL)enableVideo
+             error:(NSError *__nullable *__nullable)error;
 
 /**
  * Send the audio to the speaker
@@ -71,7 +78,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @param error Pointer to error object.
  * @return YES if successful, otherwise NO.
  */
-- (BOOL)routeAudioToSpeaker:(BOOL)speaker error:(NSError **)error;
+- (BOOL)routeAudioToSpeaker:(BOOL)speaker
+                      error:(NSError *__nullable *__nullable)error;
 
 /**
  * Send call control to call.
@@ -80,7 +88,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @param error Pointer to error object if there's an issue muting the call.
  * @return YES if succesful, NO otherwise.
  */
-- (BOOL)sendCallControl:(OCTToxAVCallControl)control toCall:(OCTCall *)call error:(NSError **)error;
+- (BOOL)sendCallControl:(OCTToxAVCallControl)control
+                 toCall:(nonnull OCTCall *)call
+                  error:(NSError *__nullable *__nullable)error;
 
 /**
  * The UIView that will have the video feed.
@@ -94,7 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param completionBlock Block responsible for using the layer. This
  * must not be nil.
  */
-- (void)getVideoCallPreview:(void (^)(CALayer *layer))completionBlock;
+- (void)getVideoCallPreview:(void (^__nonnull)( CALayer *__nullable layer))completionBlock;
 
 /**
  * Set the Audio bit rate.
@@ -102,7 +112,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @param call The Call to set the bitrate for.
  * @param error Pointer to error object if there's an issue setting the bitrate.
  */
-- (BOOL)setAudioBitrate:(int)bitrate forCall:(OCTCall *)call error:(NSError **)error;
+- (BOOL)setAudioBitrate:(int)bitrate forCall:(nonnull OCTCall *)call error:(NSError *__nullable *__nullable)error;
 
 @end
-NS_ASSUME_NONNULL_END

--- a/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
+++ b/Classes/Public/Manager/Submanagers/OCTSubmanagerCalls.h
@@ -16,9 +16,10 @@
 @class OCTToxAV;
 @class OCTCall;
 
+NS_ASSUME_NONNULL_BEGIN
 @interface OCTSubmanagerCalls : NSObject
 
-@property (weak, nonatomic) id<OCTSubmanagerCallDelegate> delegate;
+@property (nullable, weak, nonatomic) id<OCTSubmanagerCallDelegate> delegate;
 
 /**
  * Set the property to YES to enable the microphone, otherwise NO.
@@ -42,7 +43,7 @@
  * @param error Pointer to an error when attempting to answer a call
  * @return OCTCall session
  */
-- (OCTCall *)callToChat:(OCTChat *)chat enableAudio:(BOOL)enableAudio enableVideo:(BOOL)enableVideo error:(NSError **)error;
+- (nullable OCTCall *)callToChat:(OCTChat *)chat enableAudio:(BOOL)enableAudio enableVideo:(BOOL)enableVideo error:(NSError **)error;
 
 /**
  * Enable video calling for an active call.
@@ -84,7 +85,7 @@
 /**
  * The UIView that will have the video feed.
  */
-- (UIView *)videoFeed;
+- (nullable UIView *)videoFeed;
 
 /**
  * The preview video of the user.
@@ -104,3 +105,4 @@
 - (BOOL)setAudioBitrate:(int)bitrate forCall:(OCTCall *)call error:(NSError **)error;
 
 @end
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Do I need to add this for realm objects? `OCTCall` `OCTMessageCall`? Also I am only doing this classes that are exposed to the client right? In this case it's only `OCTSubmanagerCalls`

For https://github.com/Antidote-for-Tox/objcTox/issues/111
