### PR TITLE
add some facilities for submanager communication

### DIFF
--- a/Classes/Private/Manager/OCTManager.m
+++ b/Classes/Private/Manager/OCTManager.m
@@ -37,6 +37,8 @@
 
 @property (strong, nonatomic, readonly) NSObject *toxSaveFileLock;
 
+@property (strong, atomic) NSNotificationCenter *notificationCenter;
+
 @end
 
 @implementation OCTManager
@@ -57,6 +59,8 @@
     if (! self) {
         return nil;
     }
+
+    self.notificationCenter = [[NSNotificationCenter alloc] init];
 
     [self validateConfiguration:configuration];
 
@@ -154,6 +158,11 @@
 - (id<OCTFileStorageProtocol>)managerGetFileStorage
 {
     return self.configuration.fileStorage;
+}
+
+- (NSNotificationCenter *)managerGetNotificationCenter
+{
+    return self.notificationCenter;
 }
 
 #pragma mark -  Private

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerDataSource.h
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerDataSource.h
@@ -10,10 +10,25 @@
 
 @class OCTTox;
 @class OCTRealmManager;
+@class OCTSubmanagerAvatars;
+@class OCTSubmanagerBootstrap;
+@class OCTSubmanagerChats;
+@class OCTSubmanagerFiles;
+@class OCTSubmanagerFriends;
+@class OCTSubmanagerObjects;
+@class OCTSubmanagerUser;
 @protocol OCTSettingsStorageProtocol;
 @protocol OCTFileStorageProtocol;
 
 @protocol OCTSubmanagerDataSource <NSObject>
+
+@property (strong, nonatomic, readonly) OCTSubmanagerAvatars *avatars;
+@property (strong, nonatomic, readonly) OCTSubmanagerBootstrap *bootstrap;
+@property (strong, nonatomic, readonly) OCTSubmanagerChats *chats;
+@property (strong, nonatomic, readonly) OCTSubmanagerFiles *files;
+@property (strong, nonatomic, readonly) OCTSubmanagerFriends *friends;
+@property (strong, nonatomic, readonly) OCTSubmanagerObjects *objects;
+@property (strong, nonatomic, readonly) OCTSubmanagerUser *user;
 
 - (OCTTox *)managerGetTox;
 - (BOOL)managerIsToxConnected;
@@ -21,5 +36,6 @@
 - (OCTRealmManager *)managerGetRealmManager;
 - (id<OCTSettingsStorageProtocol>)managerGetSettingsStorage;
 - (id<OCTFileStorageProtocol>)managerGetFileStorage;
+- (NSNotificationCenter *)managerGetNotificationCenter;
 
 @end

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerFriends+Private.h
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerFriends+Private.h
@@ -9,6 +9,9 @@
 #import "OCTSubmanagerFriends.h"
 #import "OCTSubmanagerProtocol.h"
 
+/* object: OCTFriend whose status changed; userInfo: nil */
+extern NSString *const kOCTFriendConnectionStatusChangeNotificationName;
+
 @interface OCTSubmanagerFriends (Private) <OCTSubmanagerProtocol>
 
 @end

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerFriends.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerFriends.m
@@ -14,6 +14,8 @@
 #import "OCTRealmManager.h"
 #import "RBQFetchRequest.h"
 
+NSString *const kOCTFriendConnectionStatusChangeNotificationName = @"kOCTFriendConnectionStatusChangeNotificationName";
+
 @interface OCTSubmanagerFriends ()
 
 @end
@@ -171,11 +173,14 @@
     [self.dataSource managerSaveTox];
 
     OCTRealmManager *realmManager = [self.dataSource managerGetRealmManager];
+    OCTFriend *friend = [realmManager friendWithFriendNumber:friendNumber];
 
-    [realmManager updateObject:[realmManager friendWithFriendNumber:friendNumber] withBlock:^(OCTFriend *theFriend) {
+    [realmManager updateObject:friend withBlock:^(OCTFriend *theFriend) {
         theFriend.isConnected = (status != OCTToxConnectionStatusNone);
         theFriend.connectionStatus = status;
     }];
+
+    [[self.dataSource managerGetNotificationCenter] postNotificationName:kOCTFriendConnectionStatusChangeNotificationName object:friend];
 }
 
 #pragma mark -  Private

--- a/objcToxTests/OCTManagerTests.m
+++ b/objcToxTests/OCTManagerTests.m
@@ -36,6 +36,7 @@
 @property (strong, nonatomic, readwrite) OCTSubmanagerUser *user;
 
 @property (strong, nonatomic) OCTRealmManager *realmManager;
+@property (strong, nonatomic) NSNotificationCenter *notificationCenter;
 
 - (id)forwardingTargetForSelector:(SEL)aSelector;
 
@@ -109,6 +110,8 @@
     XCTAssertNotNil(self.manager.configuration);
     XCTAssertNotNil(self.manager.realmManager);
     XCTAssertEqualObjects(self.manager.realmManager.path, self.manager.configuration.fileStorage.pathForDatabase);
+
+    XCTAssertNotNil(self.manager.notificationCenter);
 }
 
 - (void)testBootstrap
@@ -155,6 +158,7 @@
     XCTAssertEqual([self.manager managerGetRealmManager], self.manager.realmManager);
     XCTAssertEqual([self.manager managerGetSettingsStorage], self.manager.configuration.settingsStorage);
     XCTAssertEqual([self.manager managerGetFileStorage], self.manager.configuration.fileStorage);
+    XCTAssertEqual([self.manager managerGetNotificationCenter], self.manager.notificationCenter);
 }
 
 - (void)testForwardTargetForSelector

--- a/objcToxTests/OCTSubmanagerFriendsTests.m
+++ b/objcToxTests/OCTSubmanagerFriendsTests.m
@@ -331,6 +331,19 @@ static NSString *const kMessage = @"kMessage";
     [self.submanager tox:self.tox friendConnectionStatusChanged:OCTToxConnectionStatusTCP friendNumber:kFriendNumber];
     XCTAssertEqual(friend.connectionStatus, OCTToxConnectionStatusTCP);
     XCTAssertTrue(friend.isConnected);
+
+    NSNotificationCenter *center = [[NSNotificationCenter alloc] init];
+    OCMStub([self.dataSource managerGetNotificationCenter]).andReturn(center);
+
+    XCTestExpectation *expect = [self expectationWithDescription:@""];
+    [center addObserverForName:kOCTFriendConnectionStatusChangeNotificationName object:nil queue:nil usingBlock:^(NSNotification *note) {
+        if ([note.object friendNumber] == kFriendNumber) {
+            [expect fulfill];
+        }
+    }];
+
+    [self.submanager tox:self.tox friendConnectionStatusChanged:OCTToxConnectionStatusUDP friendNumber:kFriendNumber];
+    [self waitForExpectationsWithTimeout:0.0 handler:nil];
 }
 
 #pragma mark -  Helper methods


### PR DESCRIPTION
Just a few things.
- Expose all submanagers as properties in OCTSubmanagerDataSource so they can talk directly
- Add a notification center to OCTSubmanagerDataSource so they can broadcast messages to interested submanagers. This isn't the defaultCenter so broadcasts are still framework-private.
- Add a notification post to tox:friendConnectionStatusChanged:friendNumber:.

P.S. can this be merged into file-transfers too?
