### PR TITLE
Bug fix #130 3rd party audio muted by objcTox

### DIFF
--- a/Classes/Private/Manager/Audio/OCTAudioEngine.h
+++ b/Classes/Private/Manager/Audio/OCTAudioEngine.h
@@ -21,13 +21,6 @@
 @property (nonatomic, assign) BOOL enableMicrophone;
 
 /**
- * Setup must be called once before using the audio engine.
- * @param error Pointer to error object.
- * @return YES on success, otherwise NO.
- **/
-- (BOOL)setupWithError:(NSError **)error;
-
-/**
  * Starts the Audio Processing Graph.
  * @param error Pointer to error object.
  * @return YES on success, otherwise NO.

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
@@ -53,9 +53,7 @@ const OCTToxAVVideoBitRate kDefaultVideoBitRate = 2000;
         self.videoEngine = [OCTVideoEngine new];
         self.videoEngine.toxav = self.toxAV;
 
-
-        status = [self.audioEngine setupWithError:error] &&
-                 [self.videoEngine setupWithError:error];
+        status = [self.videoEngine setupWithError:error];
     });
 
     return status;
@@ -382,7 +380,12 @@ const OCTToxAVVideoBitRate kDefaultVideoBitRate = 2000;
     if (start) {
         OCTFriend *friend = [call.chat.friends firstObject];
 
-        [self.audioEngine startAudioFlow:nil];
+        NSError *error;
+        if (! [self.audioEngine startAudioFlow:&error]) {
+            NSLog(@"Error starting audio flow %@", error);
+        }
+
+
 
         if (call.videoIsEnabled) {
             [self.videoEngine startSendingVideo];

--- a/Tests/OCTAudioEngineTests.m
+++ b/Tests/OCTAudioEngineTests.m
@@ -156,13 +156,15 @@ int16_t *pcmRender;
     OCTToxAVSampleRate sampleRate = 33333;
 
     self.audioEngine.friendNumber = 123;
+
+    _AudioUnitSetProperty = mocked_AudioUnitSetProperty;
+
     [self.audioEngine provideAudioFrames:pcm
                              sampleCount:sampleCount
                                 channels:channelCount
                               sampleRate:sampleRate
                               fromFriend:123];
 
-    _AudioUnitSetProperty = mocked_AudioUnitSetProperty;
     XCTAssertEqual((int)self.audioEngine.outputBuffer.fillCount, 16);
     XCTAssertEqual(self.audioEngine.outputSampleRate, 33333);
 #else

--- a/Tests/OCTSubmanagerCallsTests.m
+++ b/Tests/OCTSubmanagerCallsTests.m
@@ -122,13 +122,12 @@
 - (void)testSetup
 {
     OCMStub([self.mockedAudioEngine new]).andReturn(self.mockedAudioEngine);
-    OCMStub([self.mockedAudioEngine setupWithError:[OCMArg anyObjectRef]]).andReturn(YES);
 
     OCMStub([self.mockedVideoEngine new]).andReturn(self.mockedVideoEngine);
     OCMStub([self.mockedVideoEngine setupWithError:[OCMArg anyObjectRef]]).andReturn(YES);
 
     XCTAssertTrue([self.callManager setupWithError:nil]);
-    OCMVerify([self.mockedAudioEngine setupWithError:[OCMArg anyObjectRef]]);
+
     OCMVerify([self.mockedVideoEngine setupWithError:[OCMArg anyObjectRef]]);
 }
 
@@ -201,17 +200,6 @@
     XCTAssertTrue(chat.lastMessage.isOutgoing);
 }
 
-- (void)testAnswerCallFail
-{
-    [self createFriendWithFriendNumber:123];
-
-    OCTCall *call = [self.callManager createCallWithFriendNumber:123 status:OCTCallStatusRinging];
-
-    XCTAssertFalse([self.callManager answerCall:call enableAudio:YES enableVideo:NO error:nil]);
-
-    OCMVerify([self.mockedToxAV answerIncomingCallFromFriend:123 audioBitRate:48 videoBitRate:0 error:[OCMArg anyObjectRef]]);
-}
-
 - (void)testAnswerCallSuccess
 {
     OCMStub([self.mockedAudioEngine startAudioFlow:[OCMArg anyObjectRef]]).andReturn(YES);
@@ -273,9 +261,10 @@
     OCTToxAVCallState state = 0;
     state |= OCTToxAVFriendCallStateAcceptingVideo;
 
+    OCMStub([self.mockedAudioEngine startAudioFlow:[OCMArg anyObjectRef]]).andReturn(YES);
     [self.callManager toxAV:nil callStateChanged:state friendNumber:92];
 
-    OCMVerify([self.mockedAudioEngine startAudioFlow:nil]);
+    OCMVerify([self.mockedAudioEngine startAudioFlow:[OCMArg anyObjectRef]]);
     OCMVerify([self.mockedAudioEngine setFriendNumber:92]);
     OCMVerify([timer startTimerForCall:[OCMArg isNotNil]]);
 
@@ -326,10 +315,11 @@
     OCMStub([self.mockedVideoEngine isSendingVideo]).andReturn(NO);
 
     OCMStub([self.mockedToxAV sendCallControl:OCTToxAVCallControlResume toFriendNumber:12345 error:nil]).andReturn(YES);
+    OCMStub([partialMockedAudioEngine startAudioFlow:[OCMArg anyObjectRef]]).andReturn(YES);
     XCTAssertTrue([self.callManager sendCallControl:OCTToxAVCallControlResume toCall:call error:nil]);
 
     OCMVerify([self.mockedVideoEngine startSendingVideo]);
-    OCMVerify([partialMockedAudioEngine startAudioFlow:nil]);
+    OCMVerify([partialMockedAudioEngine startAudioFlow:[OCMArg anyObjectRef]]);
 }
 
 - (void)testSetAudioBitRate
@@ -356,7 +346,7 @@
 
     OCMStub([self.callManager.audioEngine isAudioRunning:nil]).andReturn(YES);
     OCMStub([self.callManager.audioEngine stopAudioFlow:[OCMArg anyObjectRef]]).andReturn(YES);
-    OCMStub([self.callManager.audioEngine startAudioFlow:nil]);
+    OCMStub([self.callManager.audioEngine startAudioFlow:[OCMArg anyObjectRef]]).andReturn(YES);
 
     [self createFriendWithFriendNumber:4];
     [self createFriendWithFriendNumber:5];
@@ -422,6 +412,7 @@
 
     self.callManager.timer = mockedTimer;
 
+    OCMStub([self.mockedAudioEngine startAudioFlow:[OCMArg anyObjectRef]]).andReturn(YES);
     [self.callManager sendCallControl:OCTToxAVCallControlResume toCall:call error:nil];
     XCTAssertEqual(call.pausedStatus, OCTCallPausedStatusNone);
 


### PR DESCRIPTION
Bug fix #130 Audio muted by objcTox

https://github.com/Antidote-for-Tox/objcTox/issues/130

Changes:
    - Remove the setup from OCTAudioEngine.
    - Graph is created at the start of audio flow.
    - Graph is destroyed when ending audio flow.
    - Fix tests for the changes above.
