### PR TITLE
Update to latest toxAV from mannol

### DIFF
--- a/Classes/Private/Manager/Database/OCTRealmManager.m
+++ b/Classes/Private/Manager/Database/OCTRealmManager.m
@@ -315,8 +315,8 @@ static NSString *kSettingsStorageObjectPrimaryKey = @"kSettingsStorageObjectPrim
 
 - (void)convertAllCallsToMessages
 {
-    RLMResults *calls = [OCTCall objectsInRealm:self.realm where:nil];
-
+    RLMResults *calls = [OCTCall allObjectsInRealm:self.realm];
+  
     DDLogInfo(@"OCTRealmManager: removing %lu calls", (unsigned long)calls.count);
 
     RBQRealmChangeLogger *logger = [self logger];

--- a/Classes/Private/Manager/Database/OCTRealmManager.m
+++ b/Classes/Private/Manager/Database/OCTRealmManager.m
@@ -316,7 +316,7 @@ static NSString *kSettingsStorageObjectPrimaryKey = @"kSettingsStorageObjectPrim
 - (void)convertAllCallsToMessages
 {
     RLMResults *calls = [OCTCall allObjectsInRealm:self.realm];
-  
+
     DDLogInfo(@"OCTRealmManager: removing %lu calls", (unsigned long)calls.count);
 
     RBQRealmChangeLogger *logger = [self logger];

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
@@ -480,9 +480,9 @@ const OCTToxAVVideoBitRate kDefaultVideoBitRate = 2000;
     [self.audioEngine provideAudioFrames:pcm sampleCount:sampleCount channels:channels sampleRate:sampleRate fromFriend:friendNumber];
 }
 
-- (void)toxAV:(OCTToxAV *)toxAV bitrateStatusForFriendNumber:(OCTToxFriendNumber)friendNumber
- audioBitRate:(OCTToxAVAudioBitRate)audioBitrate
- videoBitRate:(OCTToxAVVideoBitRate)videoBitrate
+- (void)   toxAV:(OCTToxAV *)toxAV bitrateStatusForFriendNumber:(OCTToxFriendNumber)friendNumber
+    audioBitRate:(OCTToxAVAudioBitRate)audioBitrate
+    videoBitRate:(OCTToxAVVideoBitRate)videoBitrate
 {}
 
 - (void)                 toxAV:(OCTToxAV *)toxAV

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
@@ -480,6 +480,11 @@ const OCTToxAVVideoBitRate kDefaultVideoBitRate = 2000;
     [self.audioEngine provideAudioFrames:pcm sampleCount:sampleCount channels:channels sampleRate:sampleRate fromFriend:friendNumber];
 }
 
+- (void)   toxAV:(OCTToxAV *)toxAV bitrateStatusForFriendNumber:(OCTToxFriendNumber)friendNumber
+    audioBitRate:(OCTToxAVAudioBitRate)audioBitrate
+    videoBitRate:(OCTToxAVVideoBitRate)videoBitrate
+{}
+
 - (void)                 toxAV:(OCTToxAV *)toxAV
     receiveVideoFrameWithWidth:(OCTToxAVVideoWidth)width height:(OCTToxAVVideoHeight)height
                         yPlane:(OCTToxAVPlaneData *)yPlane uPlane:(OCTToxAVPlaneData *)uPlane

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
@@ -483,7 +483,9 @@ const OCTToxAVVideoBitRate kDefaultVideoBitRate = 2000;
 - (void)   toxAV:(OCTToxAV *)toxAV bitrateStatusForFriendNumber:(OCTToxFriendNumber)friendNumber
     audioBitRate:(OCTToxAVAudioBitRate)audioBitrate
     videoBitRate:(OCTToxAVVideoBitRate)videoBitrate
-{}
+{
+    // TODO https://github.com/Antidote-for-Tox/objcTox/issues/88
+}
 
 - (void)                 toxAV:(OCTToxAV *)toxAV
     receiveVideoFrameWithWidth:(OCTToxAVVideoWidth)width height:(OCTToxAVVideoHeight)height

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
@@ -470,40 +470,6 @@ const OCTToxAVVideoBitRate kDefaultVideoBitRate = 2000;
     [self updateCall:call withState:state pausedStatus:pauseStatus];
 }
 
-- (void)toxAV:(OCTToxAV *)toxAV audioBitRateChanged:(OCTToxAVAudioBitRate)bitrate stable:(BOOL)stable friendNumber:(OCTToxFriendNumber)friendNumber
-{
-    if (stable) {
-        return;
-    }
-
-    OCTToxAVAudioBitRate newBitrate;
-
-    switch (bitrate) {
-        case OCTToxAVAudioBitRate48:
-            newBitrate = OCTToxAVAudioBitRate32;
-            break;
-        case OCTToxAVAudioBitRate32:
-            newBitrate = OCTToxAVAudioBitRate24;
-            break;
-        case OCTToxAVAudioBitRate24:
-            newBitrate = OCTToxAVAudioBitRate16;
-            break;
-        case OCTToxAVAudioBitRate16:
-            newBitrate = OCTToxAVAudioBitRate8;
-            break;
-        case OCTToxAVAudioBitRate8:
-            return;
-        case OCTToxAVAudioBitRateDisabled:
-            NSAssert(NO, @"We shouldn't be here!");
-            break;
-    }
-
-    [self.toxAV setAudioBitRate:newBitrate force:NO forFriend:friendNumber error:nil];
-}
-
-- (void)toxAV:(OCTToxAV *)toxAV videoBitRateChanged:(OCTToxAVVideoBitRate)bitrate friendNumber:(OCTToxFriendNumber)friendNumber stable:(BOOL)stable
-{}
-
 - (void)   toxAV:(OCTToxAV *)toxAV
     receiveAudio:(OCTToxAVPCMData *)pcm
      sampleCount:(OCTToxAVSampleCount)sampleCount
@@ -513,6 +479,11 @@ const OCTToxAVVideoBitRate kDefaultVideoBitRate = 2000;
 {
     [self.audioEngine provideAudioFrames:pcm sampleCount:sampleCount channels:channels sampleRate:sampleRate fromFriend:friendNumber];
 }
+
+- (void)toxAV:(OCTToxAV *)toxAV bitrateStatusForFriendNumber:(OCTToxFriendNumber)friendNumber
+ audioBitRate:(OCTToxAVAudioBitRate)audioBitrate
+ videoBitRate:(OCTToxAVVideoBitRate)videoBitrate
+{}
 
 - (void)                 toxAV:(OCTToxAV *)toxAV
     receiveVideoFrameWithWidth:(OCTToxAVVideoWidth)width height:(OCTToxAVVideoHeight)height

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerCalls.m
@@ -480,11 +480,6 @@ const OCTToxAVVideoBitRate kDefaultVideoBitRate = 2000;
     [self.audioEngine provideAudioFrames:pcm sampleCount:sampleCount channels:channels sampleRate:sampleRate fromFriend:friendNumber];
 }
 
-- (void)   toxAV:(OCTToxAV *)toxAV bitrateStatusForFriendNumber:(OCTToxFriendNumber)friendNumber
-    audioBitRate:(OCTToxAVAudioBitRate)audioBitrate
-    videoBitRate:(OCTToxAVVideoBitRate)videoBitrate
-{}
-
 - (void)                 toxAV:(OCTToxAV *)toxAV
     receiveVideoFrameWithWidth:(OCTToxAVVideoWidth)width height:(OCTToxAVVideoHeight)height
                         yPlane:(OCTToxAVPlaneData *)yPlane uPlane:(OCTToxAVPlaneData *)uPlane

--- a/Classes/Private/Wrapper/OCTToxAV+Private.h
+++ b/Classes/Private/Wrapper/OCTToxAV+Private.h
@@ -27,8 +27,8 @@ extern bool (*_toxav_call)(ToxAV *toxAV, uint32_t friend_number, uint32_t audio_
 extern bool (*_toxav_answer)(ToxAV *toxAV, uint32_t friend_number, uint32_t audio_bit_rate, uint32_t video_bit_rate, TOXAV_ERR_ANSWER *error);
 extern bool (*_toxav_call_control)(ToxAV *toxAV, uint32_t friend_number, TOXAV_CALL_CONTROL control, TOXAV_ERR_CALL_CONTROL *error);
 
-extern bool (*_toxav_audio_bit_rate_set)(ToxAV *toxAV, uint32_t friend_number, uint32_t audio_bit_rate, bool force, TOXAV_ERR_SET_BIT_RATE *error);
-extern bool (*_toxav_video_bit_rate_set)(ToxAV *toxAV, uint32_t friend_number, uint32_t audio_bit_rate, bool force, TOXAV_ERR_SET_BIT_RATE *error);
+extern bool (*_toxav_bit_rate_set)(ToxAV *toxAV, uint32_t friend_number, int32_t audio_bit_rate,
+                            int32_t video_bit_rate, TOXAV_ERR_BIT_RATE_SET *error);
 
 extern bool (*_toxav_audio_send_frame)(ToxAV *toxAV, uint32_t friend_number, const int16_t *pcm, size_t sample_count, uint8_t channels, uint32_t sampling_rate, TOXAV_ERR_SEND_FRAME *error);
 extern bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t width, uint16_t height, const uint8_t *y, const uint8_t *u, const uint8_t *v, TOXAV_ERR_SEND_FRAME *error);
@@ -38,8 +38,7 @@ extern bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uin
  */
 toxav_call_cb callIncomingCallback;
 toxav_call_state_cb callStateCallback;
-toxav_audio_bit_rate_status_cb audioBitRateStatusCallback;
-toxav_video_bit_rate_status_cb videoBitRateStatusCallback;
+toxav_bit_rate_status_cb bitRateStatusCallback;
 toxav_audio_receive_frame_cb receiveAudioFrameCallback;
 toxav_video_receive_frame_cb receiveVideoFrameCallback;
 
@@ -51,7 +50,7 @@ toxav_video_receive_frame_cb receiveVideoFrameCallback;
 - (BOOL)fillError:(NSError **)error withCErrorCall:(TOXAV_ERR_CALL)cError;
 - (BOOL)fillError:(NSError **)error withCErrorAnswer:(TOXAV_ERR_ANSWER)cError;
 - (BOOL)fillError:(NSError **)error withCErrorControl:(TOXAV_ERR_CALL_CONTROL)cError;
-- (BOOL)fillError:(NSError **)error withCErrorSetBitRate:(TOXAV_ERR_SET_BIT_RATE)cError;
+- (BOOL)fillError:(NSError **)error withCErrorSetBitRate:(TOXAV_ERR_BIT_RATE_SET)cError;
 - (BOOL)fillError:(NSError **)error withCErrorSendFrame:(TOXAV_ERR_SEND_FRAME)cError;
 - (NSError *)createErrorWithCode:(NSUInteger)code
                      description:(NSString *)description

--- a/Classes/Private/Wrapper/OCTToxAV+Private.h
+++ b/Classes/Private/Wrapper/OCTToxAV+Private.h
@@ -28,7 +28,7 @@ extern bool (*_toxav_answer)(ToxAV *toxAV, uint32_t friend_number, uint32_t audi
 extern bool (*_toxav_call_control)(ToxAV *toxAV, uint32_t friend_number, TOXAV_CALL_CONTROL control, TOXAV_ERR_CALL_CONTROL *error);
 
 extern bool (*_toxav_bit_rate_set)(ToxAV *toxAV, uint32_t friend_number, int32_t audio_bit_rate,
-                            int32_t video_bit_rate, TOXAV_ERR_BIT_RATE_SET *error);
+                                   int32_t video_bit_rate, TOXAV_ERR_BIT_RATE_SET *error);
 
 extern bool (*_toxav_audio_send_frame)(ToxAV *toxAV, uint32_t friend_number, const int16_t *pcm, size_t sample_count, uint8_t channels, uint32_t sampling_rate, TOXAV_ERR_SEND_FRAME *error);
 extern bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t width, uint16_t height, const uint8_t *y, const uint8_t *u, const uint8_t *v, TOXAV_ERR_SEND_FRAME *error);

--- a/Classes/Private/Wrapper/OCTToxAV.m
+++ b/Classes/Private/Wrapper/OCTToxAV.m
@@ -624,38 +624,6 @@ void callStateCallback(ToxAV *cToxAV,
     });
 }
 
-void audioBitRateStatusCallback(ToxAV *cToxAV,
-                                uint32_t friendNumber,
-                                bool stable,
-                                uint32_t bitRate,
-                                void *userData)
-{
-    OCTToxAV *toxAV = (__bridge OCTToxAV *)userData;
-
-    dispatch_async(dispatch_get_main_queue(), ^{
-        DDLogCInfo(@"%@: audioBitRateStatusCallback from friend %d stable: %d bitRate: %d", toxAV, friendNumber, stable, bitRate);
-        if ([toxAV.delegate respondsToSelector:@selector(toxAV:audioBitRateChanged:stable:friendNumber:)]) {
-            [toxAV.delegate toxAV:toxAV audioBitRateChanged:bitRate stable:stable friendNumber:friendNumber];
-        }
-    });
-}
-
-void videoBitRateStatusCallback(ToxAV *cToxAV,
-                                uint32_t friendNumber,
-                                bool stable,
-                                uint32_t bitRate,
-                                void *userData)
-{
-    OCTToxAV *toxAV = (__bridge OCTToxAV *)userData;
-
-    dispatch_async(dispatch_get_main_queue(), ^{
-        DDLogCInfo(@"%@: videoBitRateStatusCallback from friend %d stable: %d bitRate: %d", toxAV, friendNumber, stable, bitRate);
-        if ([toxAV.delegate respondsToSelector:@selector(toxAV:videoBitRateChanged:friendNumber:stable:)]) {
-            [toxAV.delegate toxAV:toxAV videoBitRateChanged:bitRate friendNumber:friendNumber stable:stable];
-        }
-    });
-}
-
 void bitRateStatusCallback(ToxAV *cToxAV,
                            uint32_t friendNumber,
                            uint32_t audio_bit_rate,
@@ -666,8 +634,10 @@ void bitRateStatusCallback(ToxAV *cToxAV,
 
     dispatch_async(dispatch_get_main_queue(), ^{
         DDLogCInfo(@"%@: bitRateStatusCallback from friend %d audioBitRate: %d videoBitRate: %d", toxAV, friendNumber, audio_bit_rate, video_bit_rate);
-        if ([toxAV.delegate respondsToSelector:@selector(toxAV:videoBitRateChanged:friendNumber:stable:)]) {
-            //to do
+        if ([toxAV.delegate respondsToSelector:@selector(toxAV:bitrateStatusForFriendNumber:audioBitRate:videoBitRate:)]) {
+            [toxAV.delegate toxAV:toxAV bitrateStatusForFriendNumber:friendNumber
+                     audioBitRate:audio_bit_rate
+                     videoBitRate:video_bit_rate];
         }
     });
 }

--- a/Classes/Private/Wrapper/OCTToxAV.m
+++ b/Classes/Private/Wrapper/OCTToxAV.m
@@ -634,11 +634,7 @@ void bitRateStatusCallback(ToxAV *cToxAV,
 
     dispatch_async(dispatch_get_main_queue(), ^{
         DDLogCInfo(@"%@: bitRateStatusCallback from friend %d audioBitRate: %d videoBitRate: %d", toxAV, friendNumber, audio_bit_rate, video_bit_rate);
-        if ([toxAV.delegate respondsToSelector:@selector(toxAV:bitrateStatusForFriendNumber:audioBitRate:videoBitRate:)]) {
-            [toxAV.delegate toxAV:toxAV bitrateStatusForFriendNumber:friendNumber
-                     audioBitRate:audio_bit_rate
-                     videoBitRate:video_bit_rate];
-        }
+        //TODO https://github.com/Antidote-for-Tox/objcTox/issues/88
     });
 }
 

--- a/Classes/Private/Wrapper/OCTToxAV.m
+++ b/Classes/Private/Wrapper/OCTToxAV.m
@@ -634,7 +634,11 @@ void bitRateStatusCallback(ToxAV *cToxAV,
 
     dispatch_async(dispatch_get_main_queue(), ^{
         DDLogCInfo(@"%@: bitRateStatusCallback from friend %d audioBitRate: %d videoBitRate: %d", toxAV, friendNumber, audio_bit_rate, video_bit_rate);
-        //TODO https://github.com/Antidote-for-Tox/objcTox/issues/88
+        if ([toxAV.delegate respondsToSelector:@selector(toxAV:bitrateStatusForFriendNumber:audioBitRate:videoBitRate:)]) {
+            [toxAV.delegate toxAV:toxAV bitrateStatusForFriendNumber:friendNumber
+                     audioBitRate:audio_bit_rate
+                     videoBitRate:video_bit_rate];
+        }
     });
 }
 

--- a/Classes/Private/Wrapper/OCTToxAV.m
+++ b/Classes/Private/Wrapper/OCTToxAV.m
@@ -27,8 +27,8 @@ bool (*_toxav_call)(ToxAV *toxAV, uint32_t friend_number, uint32_t audio_bit_rat
 bool (*_toxav_answer)(ToxAV *toxAV, uint32_t friend_number, uint32_t audio_bit_rate, uint32_t video_bit_rate, TOXAV_ERR_ANSWER *error);
 bool (*_toxav_call_control)(ToxAV *toxAV, uint32_t friend_number, TOXAV_CALL_CONTROL control, TOXAV_ERR_CALL_CONTROL *error);
 
-bool (*_toxav_audio_bit_rate_set)(ToxAV *toxAV, uint32_t friend_number, uint32_t audio_bit_rate, bool force, TOXAV_ERR_SET_BIT_RATE *error);
-bool (*_toxav_video_bit_rate_set)(ToxAV *toxAV, uint32_t friend_number, uint32_t audio_bit_rate, bool force, TOXAV_ERR_SET_BIT_RATE *error);
+bool (*_toxav_bit_rate_set)(ToxAV *toxAV, uint32_t friend_number, int32_t audio_bit_rate,
+                            int32_t video_bit_rate, TOXAV_ERR_BIT_RATE_SET *error);
 
 bool (*_toxav_audio_send_frame)(ToxAV *toxAV, uint32_t friend_number, const int16_t *pcm, size_t sample_count, uint8_t channels, uint32_t sampling_rate, TOXAV_ERR_SEND_FRAME *error);
 bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t width, uint16_t height, const uint8_t *y, const uint8_t *u, const uint8_t *v, TOXAV_ERR_SEND_FRAME *error);
@@ -216,9 +216,9 @@ bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t w
 
 - (BOOL)setAudioBitRate:(OCTToxAVAudioBitRate)bitRate force:(BOOL)force forFriend:(OCTToxFriendNumber)friendNumber error:(NSError **)error
 {
-    TOXAV_ERR_SET_BIT_RATE cError;
+    TOXAV_ERR_BIT_RATE_SET cError;
 
-    BOOL status = _toxav_audio_bit_rate_set(self.toxAV, friendNumber, bitRate, force, &cError);
+    BOOL status = _toxav_bit_rate_set(self.toxAV, friendNumber, bitRate, kOCTToxAVBitRateUnchanged, &cError);
 
     [self fillError:error withCErrorSetBitRate:cError];
 
@@ -229,9 +229,9 @@ bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t w
 
 - (BOOL)setVideoBitRate:(OCTToxAVVideoBitRate)bitRate force:(BOOL)force forFriend:(OCTToxFriendNumber)friendNumber error:(NSError **)error
 {
-    TOXAV_ERR_SET_BIT_RATE cError;
+    TOXAV_ERR_BIT_RATE_SET cError;
 
-    BOOL status = _toxav_video_bit_rate_set(self.toxAV, friendNumber, bitRate, force, &cError);
+    BOOL status = _toxav_bit_rate_set(self.toxAV, friendNumber, kOCTToxAVBitRateUnchanged, bitRate, &cError);
 
     [self fillError:error withCErrorSetBitRate:cError];
 
@@ -287,8 +287,7 @@ bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t w
     _toxav_answer = toxav_answer;
     _toxav_call_control = toxav_call_control;
 
-    _toxav_audio_bit_rate_set = toxav_audio_bit_rate_set;
-    _toxav_video_bit_rate_set = toxav_video_bit_rate_set;
+    _toxav_bit_rate_set = toxav_bit_rate_set;
 
     _toxav_audio_send_frame = toxav_audio_send_frame;
     _toxav_video_send_frame = toxav_video_send_frame;
@@ -298,8 +297,7 @@ bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t w
 {
     toxav_callback_call(_toxAV, callIncomingCallback, (__bridge void *)(self));
     toxav_callback_call_state(_toxAV, callStateCallback, (__bridge void *)(self));
-    toxav_callback_audio_bit_rate_status(_toxAV, audioBitRateStatusCallback, (__bridge void *)(self));
-    toxav_callback_video_bit_rate_status(_toxAV, videoBitRateStatusCallback, (__bridge void *)(self));
+    toxav_callback_bit_rate_status(_toxAV, bitRateStatusCallback, (__bridge void *)(self));
     toxav_callback_audio_receive_frame(_toxAV, receiveAudioFrameCallback, (__bridge void *)(self));
     toxav_callback_video_receive_frame(_toxAV, receiveVideoFrameCallback, (__bridge void *)(self));
 }
@@ -354,6 +352,10 @@ bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t w
             code = OCTToxAVErrorCallMalloc;
             failureReason = @"A resource allocation error occured while trying to create the structures required for the call.";
             break;
+        case TOXAV_ERR_CALL_SYNC:
+            code = OCTToxAVErrorCallSync;
+            failureReason = @"Synchronization error occurred.";
+            break;
         case TOXAV_ERR_CALL_FRIEND_NOT_FOUND:
             code = OCTToxAVErrorCallFriendNotFound;
             failureReason = @"The friend number did not designate a valid friend.";
@@ -391,6 +393,9 @@ bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t w
         case TOXAV_ERR_ANSWER_OK:
             NSAssert(NO, @"We shouldn't be here!");
             break;
+        case TOXAV_ERR_ANSWER_SYNC:
+            code = OCTToxAVErrorAnswerSync;
+            break;
         case TOXAV_ERR_ANSWER_CODEC_INITIALIZATION:
             code = OCTToxAVErrorAnswerCodecInitialization;
             break;
@@ -424,6 +429,10 @@ bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t w
         case TOXAV_ERR_CALL_CONTROL_OK:
             NSAssert(NO, @"We shouldn't be here!");
             break;
+        case TOXAV_ERR_CALL_CONTROL_SYNC:
+            code = OCTToxAVErrorControlSync;
+            failureReason = @"Synchronization error occurred.";
+            break;
         case TOXAV_ERR_CALL_CONTROL_FRIEND_NOT_FOUND:
             code = OCTToxAVErrorControlFriendNotFound;
             failureReason = @"The friend number passed did not designate a valid friend.";
@@ -443,9 +452,9 @@ bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t w
     return YES;
 }
 
-- (BOOL)fillError:(NSError **)error withCErrorSetBitRate:(TOXAV_ERR_SET_BIT_RATE)cError
+- (BOOL)fillError:(NSError **)error withCErrorSetBitRate:(TOXAV_ERR_BIT_RATE_SET)cError
 {
-    if (! error || (cError == TOXAV_ERR_SET_BIT_RATE_OK)) {
+    if (! error || (cError == TOXAV_ERR_BIT_RATE_SET_OK)) {
         return NO;
     }
 
@@ -454,18 +463,26 @@ bool (*_toxav_video_send_frame)(ToxAV *toxAV, uint32_t friend_number, uint16_t w
     NSString *failureReason = nil;
 
     switch (cError) {
-        case TOXAV_ERR_SET_BIT_RATE_OK:
+        case TOXAV_ERR_BIT_RATE_SET_OK:
             NSAssert(NO, @"We shouldn't be here!");
             break;
-        case TOXAV_ERR_SET_BIT_RATE_INVALID:
-            code = OCTToxAVErrorSetBitRateInvalid;
-            failureReason = @"The bit rate passed was not one of the supported values.";
+        case TOXAV_ERR_BIT_RATE_SET_SYNC:
+            code = OCTToxAVErrorSetBitRateSync;
+            failureReason = @"Synchronization error occurred.";
             break;
-        case TOXAV_ERR_SET_BIT_RATE_FRIEND_NOT_FOUND:
+        case TOXAV_ERR_BIT_RATE_SET_INVALID_AUDIO_BIT_RATE:
+            code = OCTToxAVErrorSetBitRateInvalidAudioBitRate;
+            failureReason = @"The audio bit rate passed was not one of the supported values.";
+            break;
+        case TOXAV_ERR_BIT_RATE_SET_INVALID_VIDEO_BIT_RATE:
+            code = OCTToxAVErrorSetBitRateInvalidVideoBitRate;
+            failureReason = @"The video bit rate passed was not one of the supported values.";
+            break;
+        case TOXAV_ERR_BIT_RATE_SET_FRIEND_NOT_FOUND:
             code = OCTToxAVErrorSetBitRateFriendNotFound;
             failureReason = @"The friend number passed did not designate a valid friend";
             break;
-        case TOXAV_ERR_SET_BIT_RATE_FRIEND_NOT_IN_CALL:
+        case TOXAV_ERR_BIT_RATE_SET_FRIEND_NOT_IN_CALL:
             code = OCTToxAVErrorSetBitRateFriendNotInCall;
             failureReason = @"This client is currently not in a call with the friend";
             break;
@@ -635,6 +652,22 @@ void videoBitRateStatusCallback(ToxAV *cToxAV,
         DDLogCInfo(@"%@: videoBitRateStatusCallback from friend %d stable: %d bitRate: %d", toxAV, friendNumber, stable, bitRate);
         if ([toxAV.delegate respondsToSelector:@selector(toxAV:videoBitRateChanged:friendNumber:stable:)]) {
             [toxAV.delegate toxAV:toxAV videoBitRateChanged:bitRate friendNumber:friendNumber stable:stable];
+        }
+    });
+}
+
+void bitRateStatusCallback(ToxAV *cToxAV,
+                           uint32_t friendNumber,
+                           uint32_t audio_bit_rate,
+                           uint32_t video_bit_rate,
+                           void *userData)
+{
+    OCTToxAV *toxAV = (__bridge OCTToxAV *)userData;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        DDLogCInfo(@"%@: bitRateStatusCallback from friend %d audioBitRate: %d videoBitRate: %d", toxAV, friendNumber, audio_bit_rate, video_bit_rate);
+        if ([toxAV.delegate respondsToSelector:@selector(toxAV:videoBitRateChanged:friendNumber:stable:)]) {
+            //to do
         }
     });
 }

--- a/Classes/Private/Wrapper/OCTToxAVConstants.m
+++ b/Classes/Private/Wrapper/OCTToxAVConstants.m
@@ -9,5 +9,6 @@
 #import "OCTToxAVConstants.h"
 
 const OCTToxAVVideoBitRate kOCTToxAVVideoBitRateDisable = 0;
+const uint32_t kOCTToxAVBitRateUnchanged = -1;
 
 NSString *const kOCTToxAVErrorDomain = @"me.dvor.objcTox.ErrorDomain";

--- a/Classes/Public/Wrapper/OCTToxAVConstants.h
+++ b/Classes/Public/Wrapper/OCTToxAVConstants.h
@@ -20,6 +20,7 @@ typedef const uint8_t OCTToxAVPlaneData;
 typedef const int32_t OCTToxAVStrideData;
 
 extern const OCTToxAVVideoBitRate kOCTToxAVVideoBitRateDisable;
+extern const uint32_t kOCTToxAVBitRateUnchanged;
 
 extern NSString *const kOCTToxAVErrorDomain;
 
@@ -113,6 +114,11 @@ typedef NS_ENUM(NSInteger, OCTToxAVErrorCall) {
     OCTToxAVErrorCallMalloc,
 
     /**
+     * Synchronization error occurred.
+     */
+    OCTToxAVErrorCallSync,
+
+    /**
      * The friend number did not designate a valid friend.
      */
     OCTToxAVErrorCallFriendNotFound,
@@ -139,6 +145,11 @@ typedef NS_ENUM(NSInteger, OCTToxAVErrorCall) {
  */
 typedef NS_ENUM(NSInteger, OCTToxAVErrorAnswer) {
     OCTToxAVErrorAnswerUnknown,
+
+    /**
+     * Synchronization error occurred.
+     */
+    OCTToxAVErrorAnswerSync,
 
     /**
      * Failed to initialize codecs for call session. Note that codec initiation
@@ -171,6 +182,11 @@ typedef NS_ENUM(NSInteger, OCTToxErrorCallControl) {
     OCTToxAVErrorControlUnknown,
 
     /**
+     * Synchronization error occurred.
+     */
+    OCTToxAVErrorControlSync,
+
+    /**
      * The friend number passed did not designate a valid friend.
      */
     OCTToxAVErrorControlFriendNotFound,
@@ -196,9 +212,19 @@ typedef NS_ENUM(NSInteger, OCTToxAVErrorSetBitRate) {
     OCTToxAVErrorSetBitRateUnknown,
 
     /**
-     * The bit rate passed was not one of the supported values.
+     * Synchronization error occured.
      */
-    OCTToxAVErrorSetBitRateInvalid,
+    OCTToxAVErrorSetBitRateSync,
+
+    /**
+     * The audio bit rate passed was not one of the supported values.
+     */
+    OCTToxAVErrorSetBitRateInvalidAudioBitRate,
+
+    /**
+     * The video bit rate passed was not one of the supported values.
+     */
+    OCTToxAVErrorSetBitRateInvalidVideoBitRate,
 
     /**
      * The friend number passed did not designate a valid friend.

--- a/Classes/Public/Wrapper/OCTToxAVDelegate.h
+++ b/Classes/Public/Wrapper/OCTToxAVDelegate.h
@@ -36,18 +36,6 @@
 - (void)toxAV:(OCTToxAV *)toxAV callStateChanged:(OCTToxAVCallState)state friendNumber:(OCTToxFriendNumber)friendNumber;
 
 /**
- * The event is triggered when the network becomes too saturated for
- * current bit rates at which point core suggests new bit rates.
- * @param friendNumber The friend number of the friend for which to set the
- * bit rate.
- * @param audio_bit_rate Suggested maximum audio bit rate in Kb/sec.
- * @param video_bit_rate Suggested maximum video bit rate in Kb/sec.
- */
-- (void)   toxAV:(OCTToxAV *)toxAV bitrateStatusForFriendNumber:(OCTToxFriendNumber)friendNumber
-    audioBitRate:(OCTToxAVAudioBitRate)audioBitrate
-    videoBitRate:(OCTToxAVVideoBitRate)videoBitrate;
-
-/**
  * Received audio frame from friend.
  * @param pcm An array of audio samples (sample_count * channels elements).
  * @param sampleCount The number of audio samples per channel in the PCM array.

--- a/Classes/Public/Wrapper/OCTToxAVDelegate.h
+++ b/Classes/Public/Wrapper/OCTToxAVDelegate.h
@@ -36,30 +36,16 @@
 - (void)toxAV:(OCTToxAV *)toxAV callStateChanged:(OCTToxAVCallState)state friendNumber:(OCTToxFriendNumber)friendNumber;
 
 /**
- * Audio bitrate has changed.
- * @param bitrate The bitrate in Kb/sec.
- * @param stable Is the stream stable enough to keep the bit rate.
- * Upon successful, non forceful, bit rate change, this is set to
- * true and 'bit_rate' is set to new bit rate.
- * The stable is set to false with bit_rate set to the unstable
- * bit rate when either current stream is unstable with said bit rate
- * or the non forceful change failed.
- * @param friendNumber Friend number of appropriate friend.
+ * The event is triggered when the network becomes too saturated for 
+ * current bit rates at which point core suggests new bit rates.
+ * @param friendNumber The friend number of the friend for which to set the
+ * bit rate.
+ * @param audio_bit_rate Suggested maximum audio bit rate in Kb/sec.
+ * @param video_bit_rate Suggested maximum video bit rate in Kb/sec.
  */
-- (void)toxAV:(OCTToxAV *)toxAV audioBitRateChanged:(OCTToxAVAudioBitRate)bitrate stable:(BOOL)stable friendNumber:(OCTToxFriendNumber)friendNumber;
-
-/**
- * Video bitrate has changed.
- * @param bitrate The bitrate in Kb/sec.
- * @param stable Is the stream stable enough to keep the bit rate.
- * Upon successful, non forceful, bit rate change, this is set to
- * true and 'bit_rate' is set to new bit rate.
- * The stable is set to false with bit_rate set to the unstable
- * bit rate when either current stream is unstable with said bit rate
- * or the non forceful change failed.
- * @param friendNumber Friend number of appropriate friend.
- */
-- (void)toxAV:(OCTToxAV *)toxAV videoBitRateChanged:(OCTToxAVVideoBitRate)bitrate friendNumber:(OCTToxFriendNumber)friendNumber stable:(BOOL)stable;
+- (void)toxAV:(OCTToxAV *)toxAV bitrateStatusForFriendNumber:(OCTToxFriendNumber)friendNumber
+                                                audioBitRate:(OCTToxAVAudioBitRate)audioBitrate
+                                                videoBitRate:(OCTToxAVVideoBitRate)videoBitrate;
 
 /**
  * Received audio frame from friend.

--- a/Classes/Public/Wrapper/OCTToxAVDelegate.h
+++ b/Classes/Public/Wrapper/OCTToxAVDelegate.h
@@ -36,6 +36,18 @@
 - (void)toxAV:(OCTToxAV *)toxAV callStateChanged:(OCTToxAVCallState)state friendNumber:(OCTToxFriendNumber)friendNumber;
 
 /**
+ * The event is triggered when the network becomes too saturated for
+ * current bit rates at which point core suggests new bit rates.
+ * @param friendNumber The friend number of the friend for which to set the
+ * bit rate.
+ * @param audio_bit_rate Suggested maximum audio bit rate in Kb/sec.
+ * @param video_bit_rate Suggested maximum video bit rate in Kb/sec.
+ */
+- (void)   toxAV:(OCTToxAV *)toxAV bitrateStatusForFriendNumber:(OCTToxFriendNumber)friendNumber
+    audioBitRate:(OCTToxAVAudioBitRate)audioBitrate
+    videoBitRate:(OCTToxAVVideoBitRate)videoBitrate;
+
+/**
  * Received audio frame from friend.
  * @param pcm An array of audio samples (sample_count * channels elements).
  * @param sampleCount The number of audio samples per channel in the PCM array.

--- a/Classes/Public/Wrapper/OCTToxAVDelegate.h
+++ b/Classes/Public/Wrapper/OCTToxAVDelegate.h
@@ -36,16 +36,16 @@
 - (void)toxAV:(OCTToxAV *)toxAV callStateChanged:(OCTToxAVCallState)state friendNumber:(OCTToxFriendNumber)friendNumber;
 
 /**
- * The event is triggered when the network becomes too saturated for 
+ * The event is triggered when the network becomes too saturated for
  * current bit rates at which point core suggests new bit rates.
  * @param friendNumber The friend number of the friend for which to set the
  * bit rate.
  * @param audio_bit_rate Suggested maximum audio bit rate in Kb/sec.
  * @param video_bit_rate Suggested maximum video bit rate in Kb/sec.
  */
-- (void)toxAV:(OCTToxAV *)toxAV bitrateStatusForFriendNumber:(OCTToxFriendNumber)friendNumber
-                                                audioBitRate:(OCTToxAVAudioBitRate)audioBitrate
-                                                videoBitRate:(OCTToxAVVideoBitRate)videoBitrate;
+- (void)   toxAV:(OCTToxAV *)toxAV bitrateStatusForFriendNumber:(OCTToxFriendNumber)friendNumber
+    audioBitRate:(OCTToxAVAudioBitRate)audioBitrate
+    videoBitRate:(OCTToxAVVideoBitRate)videoBitrate;
 
 /**
  * Received audio frame from friend.

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 inhibit_all_warnings!
 
 def common_pods
-    pod 'toxcore', :podspec => 'https://raw.githubusercontent.com/Antidote-for-Tox/toxcore/0.0.0-641b0f-new-av-2/toxcore.podspec'
+    pod 'toxcore', :podspec => 'https://raw.githubusercontent.com/Antidote-for-Tox/toxcore/0.0.0-63a82-new-av-3/toxcore.podspec'
     pod 'CocoaLumberjack', '~> 1.9.2'
     pod 'Realm', '0.95.0'
     pod 'TPCircularBuffer', '~> 0.0.1'

--- a/Tests/OCTSubmanagerCallsTests.m
+++ b/Tests/OCTSubmanagerCallsTests.m
@@ -515,21 +515,6 @@
                                                     friendNumber:444]);
 }
 
-- (void)testReceiveUnstableBitrate
-{
-    [self.callManager toxAV:self.mockedToxAV audioBitRateChanged:48 stable:NO friendNumber:1234];
-    OCMVerify([self.mockedToxAV setAudioBitRate:32 force:NO forFriend:1234 error:nil]);
-
-    [self.callManager toxAV:self.mockedToxAV audioBitRateChanged:32 stable:NO friendNumber:1234];
-    OCMVerify([self.mockedToxAV setAudioBitRate:24 force:NO forFriend:1234 error:nil]);
-
-    [self.callManager toxAV:self.mockedToxAV audioBitRateChanged:24 stable:NO friendNumber:1234];
-    OCMVerify([self.mockedToxAV setAudioBitRate:16 force:NO forFriend:1234 error:nil]);
-
-    [self.callManager toxAV:self.mockedToxAV audioBitRateChanged:16 stable:NO friendNumber:1234];
-    OCMVerify([self.mockedToxAV setAudioBitRate:8 force:NO forFriend:1234 error:nil]);
-}
-
 #pragma mark Test helper methods
 - (OCTFriend *)createFriendWithFriendNumber:(OCTToxFriendNumber)friendNumber
 {

--- a/Tests/OCTToxAVTests.m
+++ b/Tests/OCTToxAVTests.m
@@ -368,18 +368,6 @@ OCTToxAVPlaneData *aPlanePointer = aPlaneTestData;
     }];
 }
 
-- (void)testBitRateCallback
-{
-    [self makeTestCallbackWithCallBlock:^{
-        bitRateStatusCallback(NULL, 1234, 567, 890, (__bridge void *)self.toxAV);
-    } expectBlock:^(id<OCTToxAVDelegate> delegate) {
-        OCMExpect([self.toxAV.delegate toxAV:self.toxAV
-                   bitrateStatusForFriendNumber:1234
-                                   audioBitRate:567
-                                   videoBitRate:890]);
-    }];
-}
-
 - (void)testReceiveAudioCallback
 {
     const int16_t pcm[] = {5, 9, 5};

--- a/Tests/OCTToxAVTests.m
+++ b/Tests/OCTToxAVTests.m
@@ -368,6 +368,18 @@ OCTToxAVPlaneData *aPlanePointer = aPlaneTestData;
     }];
 }
 
+- (void)testBitRateCallback
+{
+    [self makeTestCallbackWithCallBlock:^{
+        bitRateStatusCallback(NULL, 1234, 567, 890, (__bridge void *)self.toxAV);
+    } expectBlock:^(id<OCTToxAVDelegate> delegate) {
+        OCMExpect([self.toxAV.delegate toxAV:self.toxAV
+                   bitrateStatusForFriendNumber:1234
+                                   audioBitRate:567
+                                   videoBitRate:890]);
+    }];
+}
+
 - (void)testReceiveAudioCallback
 {
     const int16_t pcm[] = {5, 9, 5};

--- a/Tests/OCTToxAVTests.m
+++ b/Tests/OCTToxAVTests.m
@@ -374,9 +374,9 @@ OCTToxAVPlaneData *aPlanePointer = aPlaneTestData;
         bitRateStatusCallback(NULL, 1234, 567, 890, (__bridge void *)self.toxAV);
     } expectBlock:^(id<OCTToxAVDelegate> delegate) {
         OCMExpect([self.toxAV.delegate toxAV:self.toxAV
-                bitrateStatusForFriendNumber:1234
-                                audioBitRate:567
-                                videoBitRate:890]);
+                   bitrateStatusForFriendNumber:1234
+                                   audioBitRate:567
+                                   videoBitRate:890]);
     }];
 }
 

--- a/Tests/OCTToxAVTests.m
+++ b/Tests/OCTToxAVTests.m
@@ -32,8 +32,8 @@ bool mocked_tox_av_call_fail(ToxAV *toxAV, uint32_t friend_number, uint32_t audi
 bool mocked_toxav_call_control_resume(ToxAV *toxAV, uint32_t friend_number, TOXAV_CALL_CONTROL control, TOXAV_ERR_CALL_CONTROL *error);
 bool mocked_toxav_call_control_cancel(ToxAV *toxAV, uint32_t friend_number, TOXAV_CALL_CONTROL control, TOXAV_ERR_CALL_CONTROL *error);
 
-bool mocked_toxav_audio_bit_rate_set(ToxAV *toxAV, uint32_t friend_number, uint32_t audio_bit_rate, bool force, TOXAV_ERR_SET_BIT_RATE *error);
-bool mocked_toxav_video_bit_rate_set(ToxAV *toxAV, uint32_t friend_number, uint32_t audio_bit_rate, bool force, TOXAV_ERR_SET_BIT_RATE *error);
+bool mocked_toxav_bit_rate_set(ToxAV *toxAV, uint32_t friend_number, int32_t audio_bit_rate,
+                               int32_t video_bit_rate, TOXAV_ERR_BIT_RATE_SET *error);
 
 bool mocked_toxav_audio_send_frame(ToxAV *toxAV, uint32_t friend_number, const int16_t *pcm, size_t sample_count, uint8_t channels, uint32_t sampling_rate, TOXAV_ERR_SEND_FRAME *error);
 bool mocked_toxav_video_send_frame(ToxAV *toxAV, uint32_t friend_number, uint16_t width, uint16_t height, const uint8_t *y, const uint8_t *u, const uint8_t *v, TOXAV_ERR_SEND_FRAME *error);
@@ -141,19 +141,6 @@ OCTToxAVPlaneData *aPlanePointer = aPlaneTestData;
 
     _toxav_iterate = nil;
     _toxav_iteration_interval = nil;
-}
-
-- (void)testSetAudioBitRate
-{
-
-    _toxav_audio_bit_rate_set = mocked_toxav_audio_bit_rate_set;
-    XCTAssertTrue([self.toxAV setAudioBitRate:1111 force:YES forFriend:5678 error:nil]);
-}
-
-- (void)testSetVideoBitRate
-{
-    _toxav_video_bit_rate_set = mocked_toxav_video_bit_rate_set;
-    XCTAssertFalse([self.toxAV setVideoBitRate:10 force:NO forFriend:5 error:nil]);
 }
 
 - (void)testSendAudioFrame
@@ -270,20 +257,30 @@ OCTToxAVPlaneData *aPlanePointer = aPlaneTestData;
 }
 - (void)testFillErrorSetBitRate
 {
-    [self.toxAV fillError:nil withCErrorSetBitRate:TOXAV_ERR_SET_BIT_RATE_FRIEND_NOT_IN_CALL];
+    [self.toxAV fillError:nil withCErrorSetBitRate:TOXAV_ERR_BIT_RATE_SET_FRIEND_NOT_IN_CALL];
 
     NSError *error;
-    [self.toxAV fillError:&error withCErrorSetBitRate:TOXAV_ERR_SET_BIT_RATE_INVALID];
+    [self.toxAV fillError:&error withCErrorSetBitRate:TOXAV_ERR_BIT_RATE_SET_INVALID_AUDIO_BIT_RATE];
     XCTAssertNotNil(error);
-    XCTAssertTrue(error.code == OCTToxAVErrorSetBitRateInvalid);
+    XCTAssertTrue(error.code == OCTToxAVErrorSetBitRateInvalidAudioBitRate);
 
     error = nil;
-    [self.toxAV fillError:&error withCErrorSetBitRate:TOXAV_ERR_SET_BIT_RATE_FRIEND_NOT_FOUND];
+    [self.toxAV fillError:&error withCErrorSetBitRate:TOXAV_ERR_BIT_RATE_SET_SYNC];
+    XCTAssertNotNil(error);
+    XCTAssertTrue(error.code == OCTToxAVErrorSetBitRateSync);
+
+    error = nil;
+    [self.toxAV fillError:&error withCErrorSetBitRate:TOXAV_ERR_BIT_RATE_SET_INVALID_VIDEO_BIT_RATE];
+    XCTAssertNotNil(error);
+    XCTAssertTrue(error.code == OCTToxAVErrorSetBitRateInvalidVideoBitRate);
+
+    error = nil;
+    [self.toxAV fillError:&error withCErrorSetBitRate:TOXAV_ERR_BIT_RATE_SET_FRIEND_NOT_FOUND];
     XCTAssertNotNil(error);
     XCTAssertTrue(error.code == OCTToxAVErrorSetBitRateFriendNotFound);
 
     error = nil;
-    [self.toxAV fillError:&error withCErrorSetBitRate:TOXAV_ERR_SET_BIT_RATE_FRIEND_NOT_IN_CALL];
+    [self.toxAV fillError:&error withCErrorSetBitRate:TOXAV_ERR_BIT_RATE_SET_FRIEND_NOT_IN_CALL];
     XCTAssertNotNil(error);
     XCTAssertTrue(error.code == OCTToxAVErrorSetBitRateFriendNotInCall);
 }
@@ -371,27 +368,15 @@ OCTToxAVPlaneData *aPlanePointer = aPlaneTestData;
     }];
 }
 
-- (void)testAudioBitRateCallback
+- (void)testBitRateCallback
 {
     [self makeTestCallbackWithCallBlock:^{
-        audioBitRateStatusCallback(NULL, 33, true, 33000, (__bridge void *)self.toxAV);
+        bitRateStatusCallback(NULL, 1234, 567, 890, (__bridge void *)self.toxAV);
     } expectBlock:^(id<OCTToxAVDelegate> delegate) {
         OCMExpect([self.toxAV.delegate toxAV:self.toxAV
-                         audioBitRateChanged:33000
-                                      stable:YES
-                                friendNumber:33]);
-    }];
-}
-
-- (void)testVideoBitRateCallback
-{
-    [self makeTestCallbackWithCallBlock:^{
-        videoBitRateStatusCallback(NULL, 5, false, 10, (__bridge void *)self.toxAV);
-    } expectBlock:^(id<OCTToxAVDelegate> delegate) {
-        OCMExpect([self.toxAV.delegate toxAV:self.toxAV
-                         videoBitRateChanged:10
-                                friendNumber:5
-                                      stable:NO]);
+                bitrateStatusForFriendNumber:1234
+                                audioBitRate:567
+                                videoBitRate:890]);
     }];
 }
 
@@ -573,18 +558,8 @@ bool mocked_toxav_call_control_cancel(ToxAV *cToxAV, uint32_t friend_number, TOX
     return true;
 }
 
-bool mocked_toxav_audio_bit_rate_set(ToxAV *cToxAV, uint32_t friend_number, uint32_t audio_bit_rate, bool force, TOXAV_ERR_SET_BIT_RATE *error)
-{
-    OCTToxAV *toxAV = [(__bridge OCTToxAVTests *)refToSelf toxAV];
-
-    CCCAssertTrue(toxAV.toxAV == cToxAV);
-
-    CCCAssertEqual(5678, friend_number);
-    CCCAssertEqual(1111, audio_bit_rate);
-    CCCAssertTrue(force);
-    return true;
-}
-bool mocked_toxav_video_bit_rate_set(ToxAV *cToxAV, uint32_t friend_number, uint32_t audio_bit_rate, bool force, TOXAV_ERR_SET_BIT_RATE *error)
+bool mocked_toxav_bit_rate_set(ToxAV *cToxAV, uint32_t friend_number, int32_t audio_bit_rate,
+                               int32_t video_bit_rate, TOXAV_ERR_BIT_RATE_SET *error)
 {
     OCTToxAV *toxAV = [(__bridge OCTToxAVTests *)refToSelf toxAV];
 
@@ -592,9 +567,9 @@ bool mocked_toxav_video_bit_rate_set(ToxAV *cToxAV, uint32_t friend_number, uint
 
     CCCAssertEqual(5, friend_number);
     CCCAssertEqual(10, audio_bit_rate);
-    CCCAssertFalse(force);
 
     return false;
+
 }
 
 bool mocked_toxav_audio_send_frame(ToxAV *cToxAV, uint32_t friend_number, const int16_t *pcm, size_t sample_count, uint8_t channels, uint32_t sampling_rate, TOXAV_ERR_SEND_FRAME *error)

--- a/objcTox.podspec
+++ b/objcTox.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Classes/**/*.{m,h}'
   s.public_header_files = 'Classes/Public/**/*.h'
-  s.dependency 'toxcore', '0.0.0-641b0f-new-av-2'
+  s.dependency 'toxcore', '0.0.0-63a82-new-av-3'
   s.dependency 'TPCircularBuffer', '~> 0.0.1'
   s.dependency 'CocoaLumberjack', '1.9.2'
   s.dependency 'Realm', '0.95.0'


### PR DESCRIPTION
Some new enums were added from toxav.

Did `$ xctool -workspace objcTox.xcworkspace -scheme iOSDemo -sdk iphonesimulator CODE_SIGNING_REQUIRED=NO GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean test`

But got one error:
`Unable to read build settings for target 'iOSDemoTests'.  It's likely that the scheme references a non-existent target.`

`xcodebuild: error: The test action requires that the name of a scheme in the project is provided using the "-scheme" option. The "-list" option can be used to find the names of the schemes in the project.`

However all tests pass when running them in xcode
