### PR TITLE
Last Seen online bug fix

### DIFF
--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerFriends.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerFriends.m
@@ -106,6 +106,8 @@ NSString *const kOCTFriendConnectionStatusChangeNotificationName = @"kOCTFriendC
             friend.isConnected = NO;
             friend.connectionStatus = OCTToxConnectionStatusNone;
             friend.isTyping = NO;
+            NSDate *dateOffline = [[self.dataSource managerGetTox] friendGetLastOnlineWithFriendNumber:friend.friendNumber error:nil];
+            friend.lastSeenOnlineInterval = [dateOffline timeIntervalSince1970];
         }
     }];
 
@@ -216,9 +218,6 @@ NSString *const kOCTFriendConnectionStatusChangeNotificationName = @"kOCTFriendC
             NSDate *dateOffline = [tox friendGetLastOnlineWithFriendNumber:friendNumber error:nil];
             NSTimeInterval timeSince = [dateOffline timeIntervalSince1970];
             theFriend.lastSeenOnlineInterval = timeSince;
-        }
-        else {
-            theFriend.lastSeenOnlineInterval = 0;
         }
     }];
 

--- a/Classes/Private/Manager/Submanagers/OCTSubmanagerFriends.m
+++ b/Classes/Private/Manager/Submanagers/OCTSubmanagerFriends.m
@@ -211,6 +211,15 @@ NSString *const kOCTFriendConnectionStatusChangeNotificationName = @"kOCTFriendC
     [realmManager updateObject:friend withBlock:^(OCTFriend *theFriend) {
         theFriend.isConnected = (status != OCTToxConnectionStatusNone);
         theFriend.connectionStatus = status;
+
+        if (! theFriend.isConnected) {
+            NSDate *dateOffline = [tox friendGetLastOnlineWithFriendNumber:friendNumber error:nil];
+            NSTimeInterval timeSince = [dateOffline timeIntervalSince1970];
+            theFriend.lastSeenOnlineInterval = timeSince;
+        }
+        else {
+            theFriend.lastSeenOnlineInterval = 0;
+        }
     }];
 
     [[self.dataSource managerGetNotificationCenter] postNotificationName:kOCTFriendConnectionStatusChangeNotificationName object:friend];

--- a/OSXDemo/OCTUserViewController.m
+++ b/OSXDemo/OCTUserViewController.m
@@ -138,7 +138,7 @@ static NSString *const kTableViewIdentifier = @"userTableViewIdent";
 
 #pragma mark -  OCTSubmanagerUserDelegate
 
-- (void)OCTSubmanagerUser:(OCTSubmanagerUser *)submanager connectionStatusUpdate:(OCTToxConnectionStatus)connectionStatus
+- (void)submanagerUser:(OCTSubmanagerUser *)submanager connectionStatusUpdate:(OCTToxConnectionStatus)connectionStatus
 {
     [self.userTableView reloadData];
 }

--- a/Tests/OCTSubmanagerFriendsTests.m
+++ b/Tests/OCTSubmanagerFriendsTests.m
@@ -374,10 +374,6 @@ static NSString *const kMessage = @"kMessage";
     [self stubFriendMethodsInTox];
     [self.submanager tox:self.tox friendConnectionStatusChanged:OCTToxConnectionStatusNone friendNumber:kFriendNumber];
     XCTAssertEqual(friend.lastSeenOnlineInterval, [sLastSeenOnline timeIntervalSince1970]);
-
-    [self.submanager tox:self.tox friendConnectionStatusChanged:OCTToxConnectionStatusTCP friendNumber:kFriendNumber];
-    XCTAssertNil([friend lastSeenOnline]);
-    XCTAssertEqual(0, friend.lastSeenOnlineInterval);
 }
 
 - (void)testIsTypingUpdate

--- a/Tests/OCTSubmanagerFriendsTests.m
+++ b/Tests/OCTSubmanagerFriendsTests.m
@@ -354,6 +354,32 @@ static NSString *const kMessage = @"kMessage";
     XCTAssertEqual(friend.status, kStatus);
 }
 
+- (void)testLastSeenDate
+{
+    OCTFriend *friend = [self createFriend];
+    friend.friendNumber = kFriendNumber;
+    friend.lastSeenOnlineInterval = 0;
+
+    [self.realmManager.realm beginWriteTransaction];
+    [self.realmManager.realm addObject:friend];
+    [self.realmManager.realm commitWriteTransaction];
+
+    XCTAssertNil([friend lastSeenOnline]);
+
+    [self.submanager tox:self.tox friendConnectionStatusChanged:OCTToxConnectionStatusTCP friendNumber:kFriendNumber];
+
+    XCTAssertNil([friend lastSeenOnline]);
+    XCTAssertEqual(friend.lastSeenOnlineInterval, 0);
+
+    [self stubFriendMethodsInTox];
+    [self.submanager tox:self.tox friendConnectionStatusChanged:OCTToxConnectionStatusNone friendNumber:kFriendNumber];
+    XCTAssertEqual(friend.lastSeenOnlineInterval, [sLastSeenOnline timeIntervalSince1970]);
+
+    [self.submanager tox:self.tox friendConnectionStatusChanged:OCTToxConnectionStatusTCP friendNumber:kFriendNumber];
+    XCTAssertNil([friend lastSeenOnline]);
+    XCTAssertEqual(0, friend.lastSeenOnlineInterval);
+}
+
 - (void)testIsTypingUpdate
 {
     OCTFriend *friend = [self createFriend];


### PR DESCRIPTION
For https://github.com/Antidote-for-Tox/objcTox/issues/151

The lastSeenOnlineInterval is always updated after a friend's connection
status goes to offline. If friend goes online, the last seen online will
be nil. Subsequently the lastSeenInterval is set to 0.
