### PR TITLE
get CVPixelBuffer's stride instead of assuming

### DIFF
--- a/Classes/Private/Manager/Video/OCTVideoEngine.m
+++ b/Classes/Private/Manager/Video/OCTVideoEngine.m
@@ -242,16 +242,19 @@ static const OSType kPixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRan
     }
 
     uint8_t *yDestinationPlane = CVPixelBufferGetBaseAddressOfPlane(bufferRef, 0);
+    size_t yDestinationStride = CVPixelBufferGetBytesPerRowOfPlane(bufferRef, 0);
 
     /* Copy yPlane data */
     for (size_t yHeight = 0; yHeight < height; yHeight++) {
         memcpy(yDestinationPlane, ySource, yBytesPerRow);
         ySource += yStride;
-        yDestinationPlane += yBytesPerRow;
+        yDestinationPlane += yDestinationStride;
     }
 
     /* Interweave U and V */
     uint8_t *uvDestinationPlane = CVPixelBufferGetBaseAddressOfPlane(bufferRef, 1);
+    size_t uvDestinationStride = CVPixelBufferGetBytesPerRowOfPlane(bufferRef, 1);
+
     OCTToxAVPlaneData *uSource = uPlane;
     if (uStride < 0) {
         uSource = uSource + ((-uStride) * ((height / 2) - 1));
@@ -267,7 +270,7 @@ static const OSType kPixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRan
             uvDestinationPlane[index * 2] = uSource[index];
             uvDestinationPlane[(index * 2) + 1] = vSource[index];
         }
-        uvDestinationPlane += uvBytesPerRow * 2;
+        uvDestinationPlane += uvDestinationStride;
         uSource += uStride;
         vSource += vStride;
     }

--- a/Tests/OCTVideoEngineTests.m
+++ b/Tests/OCTVideoEngineTests.m
@@ -170,8 +170,21 @@
         uint8_t *y = CVPixelBufferGetBaseAddressOfPlane(pb, 0);
         uint8_t *uv = CVPixelBufferGetBaseAddressOfPlane(pb, 1);
 
-        XCTAssertEqual(memcmp(y, test_good_y, sizeof(test_good_y)), 0);
-        XCTAssertEqual(memcmp(uv, test_good_uv, sizeof(test_good_uv)), 0);
+        uint8_t *testyrow = y;
+        uint8_t *goodyrow = test_good_y;
+        for (int i = 0; i < 30; ++i) {
+            XCTAssertEqual(memcmp(testyrow, goodyrow, 30), 0);
+            testyrow += CVPixelBufferGetBytesPerRowOfPlane(pb, 0);
+            goodyrow += 30;
+        }
+
+        uint8_t *testuvrow = uv;
+        uint8_t *gooduvrow = test_good_uv;
+        for (int i = 0; i < 15; ++i) {
+            XCTAssertEqual(memcmp(testuvrow, gooduvrow, 30), 0);
+            testuvrow += CVPixelBufferGetBytesPerRowOfPlane(pb, 1);
+            gooduvrow += 30;
+        }
 
         void *ret = nil;
         [invocation setReturnValue:&ret];


### PR DESCRIPTION
It was causing scrambled video.
